### PR TITLE
change: clean up global styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> Predictive Text Studio </title>
-  <link rel="stylesheet" href="style.css" media="all">
   <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400;0,700;1,400&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
   <!-- TODO: insert SEO tags -->
 </head>

--- a/public/index.html
+++ b/public/index.html
@@ -5,9 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title> Predictive Text Studio </title>
   <link rel="stylesheet" href="style.css" media="all">
-  <link
-    href="https://fonts.googleapis.com/css?family=Cabin:400,400italic,500,600,700,700italic|Source+Sans+Pro:400,700,900,600,300|Noto+Serif:400"
-    rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400;0,700;1,400&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
   <!-- TODO: insert SEO tags -->
 </head>
 <body>

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -7,18 +7,32 @@
 
 <style>
   :global(:root) {
-    --blue: #6fbbd4;
-    --blue-light: #b3dbe7;
-    --red: #b90529;
-    --red-light: #de929c;
-    --orange: #f18407;
-    --orange-light: #fbc88f;
+    /* Keyman brand colours, derived from https://keyman.com/ */
+    --blue: #6FBBD4;
+    --blue-light: #B3DBE7;
+    --red: #B90529;
+    --red-light: #DE929C;
+    --orange: #F18407;
+    --orange-light: #FBC88F;
     --gray: #888888;
-    --gray-light: #d6d6d6;
+    --gray-light: #D6D6D6;
+
+    /* Font stack */
+    /* Custom fonts downloaded from Google Fonts -- see public/index.html */
+    --main-font: "Cabin";
+    --mono-font: "Roboto Mono";
   }
 
-  :global(:root) {
-    font-family: "Carbin", sans-serif;
+  :global(body) {
+    font-family: var(--main-font), sans-serif;
+  }
+
+  :global(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--main-font), sans-serif;
+  }
+
+  :global(pre, code, samp) {
+    font-family: var(--mono-font), monospace;
   }
 </style>
 


### PR DESCRIPTION
This cleans up some of the Keyman brand colours introduced by @jienius. It also uses the font stack that @pranavnarang used in the Figma mockups (#18). I would appreciate a review from you both!

resolves #44
