### PR TITLE
feat: create zip with files

### DIFF
--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -1,11 +1,7 @@
 import * as JSZip from "jszip";
 
-export function generateZip(zip: JSZip): Promise<Buffer> {
-  return zip.generateAsync({ type: "nodebuffer" });
-}
-
 /**
- * Given a list of filenames and string contents, generates a ZIP file.
+ * A list of filenames and their contents as a string.
  */
 type FileList = { [filename: string]: string };
 

--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -10,5 +10,10 @@ export function generateZip(zip: JSZip): Promise<Buffer> {
 type FileList = { [filename: string]: string };
 
 export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
-  return Promise.reject(new Error("not implemented"));
+  const zip = new JSZip();
+  for (const [filename, contents] of Object.entries(files)) {
+    zip.file(filename, contents);
+  }
+
+  return zip.generateAsync({ type: "arraybuffer" });
 }

--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -3,3 +3,12 @@ import * as JSZip from "jszip";
 export function generateZip(zip: JSZip): Promise<Buffer> {
   return zip.generateAsync({ type: "nodebuffer" });
 }
+
+/**
+ * Given a list of filenames and string contents, generates a ZIP file.
+ */
+type FileList = { [filename: string]: string };
+
+export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
+  return Promise.reject(new Error("not implemented"));
+}

--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -9,6 +9,16 @@ export function generateZip(zip: JSZip): Promise<Buffer> {
  */
 type FileList = { [filename: string]: string };
 
+/**
+ * Given a series of filename/content pairs, creates a .zip file.
+ *
+ * For create a .kmp file, do the following:
+ *
+ *  let kmpFile = async createZipWithFiles({
+ *      [`${modelID}.model.js`]: compiledModelCode,
+ *      "kmp.json": JSON.stringify(modelInfo)
+ *  })
+ */
 export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
   const zip = new JSZip();
   for (const [filename, contents] of Object.entries(files)) {

--- a/test/test-generate-zip.ts
+++ b/test/test-generate-zip.ts
@@ -1,15 +1,6 @@
 import test from "ava";
-import * as JSZip from "jszip";
 
-import { generateZip, createZipWithFiles } from "@worker/generate-zip";
-
-const zip = new JSZip();
-zip.file("Hello.txt", "Hello World\n");
-
-test("it should generate a zip file and return", async (t) => {
-  const file = await generateZip(zip);
-  t.assert(file.length > 0);
-});
+import { createZipWithFiles } from "@worker/generate-zip";
 
 test("it should create a ZIP file with the given contents", async (t) => {
   const zip = await createZipWithFiles({

--- a/test/test-generate-zip.ts
+++ b/test/test-generate-zip.ts
@@ -1,7 +1,7 @@
 import test from "ava";
 import * as JSZip from "jszip";
 
-import { generateZip } from "@worker/generate-zip";
+import { generateZip, createZipWithFiles } from "@worker/generate-zip";
 
 const zip = new JSZip();
 zip.file("Hello.txt", "Hello World\n");
@@ -9,4 +9,19 @@ zip.file("Hello.txt", "Hello World\n");
 test("it should generate a zip file and return", async (t) => {
   const file = await generateZip(zip);
   t.assert(file.length > 0);
+});
+
+test("it should create a ZIP file with the given contents", async (t) => {
+  const zip = await createZipWithFiles({
+    "nobody.en.example.model.js": "(function() {'use strict'}())",
+    "kmp.json": '{"license":"mit","languages":["en"]}',
+  });
+  t.assert(zip.byteLength > 0);
+
+  // The first two bytes of any Zip file is "PK" in ASCII:
+  const view = new Uint8Array(zip.slice(0, 2));
+  t.is("P".charCodeAt(0), view[0]);
+  t.is("K".charCodeAt(0), view[1]);
+
+  // TODO: ensure our content actually exists in the zip file!
 });


### PR DESCRIPTION
Replaces `generateZip()` with `createZipWithFiles()`. This creates an `ArrayBuffer`, which is supported both in NodeJS and in the browser. Not to mention, is compatible with the DOM [File](https://developer.mozilla.org/en-US/docs/Web/API/File) interface.
