### PR TITLE
change(worker): include the JSZip bundle separately

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Compiled files:
 public/app.js
 public/worker.js
+# Copied files
+public/jszip.min.js
 
 # Source maps
 *.js.map

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,8 @@ import { terser } from "rollup-plugin-terser";
 import json from "@rollup/plugin-json";
 
 import * as child_process from "child_process";
+import * as fs from "fs";
+import * as path from "path";
 
 //////////////////////////////// Environment /////////////////////////////////
 const production = !process.env.ROLLUP_WATCH;
@@ -75,6 +77,8 @@ const workerConfiguration = {
     }),
     commonjs(),
 
+    copyJSZipBundle(),
+
     // Minify in production
     production && terser(),
   ],
@@ -120,6 +124,28 @@ function serve() {
 
       process.on("SIGTERM", stopServer);
       process.on("exit", stopServer);
+    },
+  };
+}
+
+/**
+ * Rollup plugin that copies jszip.min.js from node_modules to be a SIBLING of
+ * the desired bundle.
+ */
+function copyJSZipBundle() {
+  return {
+    name: "copy-jszip-bundle",
+    generateBundle(options) {
+      const parentDir = path.dirname(path.resolve(options.file));
+      const destination = path.join(parentDir, "jszip.min.js");
+      const source = path.join(
+        __dirname,
+        "node_modules",
+        "jszip",
+        "dist",
+        "jszip.min.js"
+      );
+      fs.copyFileSync(source, destination);
     },
   };
 }

--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -1,4 +1,4 @@
-import * as JSZip from "jszip";
+import type * as JSZip from "jszip";
 
 /**
  * A list of filenames and their contents as a string.
@@ -16,10 +16,32 @@ type FileList = { [filename: string]: string };
  *  })
  */
 export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
-  const zip = new JSZip();
+  const zip = createJSZip();
   for (const [filename, contents] of Object.entries(files)) {
     zip.file(filename, contents);
   }
 
   return zip.generateAsync({ type: "arraybuffer" });
+}
+
+/**
+ * This pile of hacks tries to load the JSZip library, whether in Node.JS or
+ * in the WebWorker context.
+ *
+ * In the WebWorker context, it is assumed that JSZip was loaded globally, and
+ * is accessible as self.JSZip.
+ *
+ * In Node.JS, you require() it like any other module.
+ */
+function createJSZip(): JSZip {
+  let Constructor: typeof JSZip;
+
+  if (typeof self != "undefined" && (self as { JSZip?: JSZip }).JSZip) {
+    // Within the WebWorker:
+    Constructor = ((self as unknown) as { JSZip: JSZip }).JSZip;
+  } else {
+    // Within Node.js (Ava unit tests, probably)
+    Constructor = require("jszip");
+  }
+  return new Constructor();
 }

--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -24,6 +24,10 @@ export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
   return zip.generateAsync({ type: "arraybuffer" });
 }
 
+////////////////////////////////// Helpers ///////////////////////////////////
+
+type JSZipConstructor = new () => JSZip;
+
 /**
  * This pile of hacks tries to load the JSZip library, whether in Node.JS or
  * in the WebWorker context.
@@ -34,7 +38,7 @@ export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
  * In Node.JS, you require() it like any other module.
  */
 function createJSZip(): JSZip {
-  let Constructor: typeof JSZip;
+  let Constructor: JSZipConstructor;
 
   if (typeof self !== "undefined" && jsZipIsDefinedWithin(self)) {
     // Within the WebWorker:
@@ -46,7 +50,9 @@ function createJSZip(): JSZip {
   return new Constructor();
 }
 
-type WorkerGlobalScopeWithJSZip = WorkerGlobalScope & { JSZip: typeof JSZip };
+type WorkerGlobalScopeWithJSZip = WorkerGlobalScope & {
+  JSZip: JSZipConstructor;
+};
 
 /**
  * This **type guard** returns true when the global scope seems to have the

--- a/src/worker/generate-zip.ts
+++ b/src/worker/generate-zip.ts
@@ -36,12 +36,30 @@ export function createZipWithFiles(files: FileList): Promise<ArrayBuffer> {
 function createJSZip(): JSZip {
   let Constructor: typeof JSZip;
 
-  if (typeof self != "undefined" && (self as { JSZip?: JSZip }).JSZip) {
+  if (typeof self !== "undefined" && jsZipIsDefinedWithin(self)) {
     // Within the WebWorker:
-    Constructor = ((self as unknown) as { JSZip: JSZip }).JSZip;
+    Constructor = self.JSZip;
   } else {
     // Within Node.js (Ava unit tests, probably)
     Constructor = require("jszip");
   }
   return new Constructor();
+}
+
+type WorkerGlobalScopeWithJSZip = WorkerGlobalScope & { JSZip: typeof JSZip };
+
+/**
+ * This **type guard** returns true when the global scope seems to have the
+ * JSZip constructor defined.
+ *
+ * When used in an `if ()` condition, then the scope within the if-block
+ * **definitely** has a global called JSZip!
+ *
+ * See: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
+ */
+function jsZipIsDefinedWithin(
+  scope: WorkerGlobalScope
+): scope is WorkerGlobalScopeWithJSZip {
+  const augmentedScope = scope as Partial<WorkerGlobalScopeWithJSZip>;
+  return typeof augmentedScope.JSZip === "function";
 }

--- a/src/worker/main.ts
+++ b/src/worker/main.ts
@@ -2,6 +2,9 @@ import { readExcel } from "./read-wordlist";
 import { SaveFileEventPayload } from "@common/events";
 import Storage from "./storage";
 
+/* Load the official JSZip web distribution bundle.  */
+importScripts("jszip.min.js");
+
 const storage = new Storage();
 
 const handleSaveFileEvent = async (event: MessageEvent) => {


### PR DESCRIPTION
This PR is pile of hacks, but it gets zip file generation working, so ¯\\\_(ツ)\_/¯ 

JSZip did not want to be bundled by Rollup, so instead of trying to fit it in our bundle, I used `importScript()` in the WebWorker context.

I modified the Rollup config so that it automatically copies the `jszip.min.js` from the JSZip npm package, so no need to commit it or copy it manually; it happens when the worker bundle is built! 


This PR is blocking #78!
