### PR TITLE
refactor(test): factor out common setup code

### DIFF
--- a/test/test-storage.ts
+++ b/test/test-storage.ts
@@ -34,8 +34,7 @@ test.beforeEach((t) => {
 });
 
 test("storing a file", async (t) => {
-  const db = t.context.db;
-  const storage = t.context.storage;
+  const { db, storage } = t.context;
 
   // At first, there's nothing in the DB:
   t.is(await db.files.count(), 0);
@@ -46,10 +45,10 @@ test("storing a file", async (t) => {
 });
 
 test("retrieving one file with .fetchAllFiles()", async (t) => {
-  const storage = t.context.storage;
-  const filename = "ExampleWordlist.xlsx";
+  const { storage } = t.context;
 
-  // Let's store ExampleWordlist!
+  // Let's store a file that we will later try to fetch:
+  const filename = "ExampleWordlist.xlsx";
   await storage.saveFile(filename, exampleWordlist);
 
   // We should find that it has been stored:
@@ -62,7 +61,7 @@ test("retrieving one file with .fetchAllFiles()", async (t) => {
 });
 
 test("retrieving mulitple files with .fetchAllFiles()", async (t) => {
-  const storage = t.context.storage;
+  const { storage } = t.context;
 
   const sources = [
     { name: "ExampleWordlist.xlsx", wordlist: exampleWordlist },

--- a/test/test-storage.ts
+++ b/test/test-storage.ts
@@ -1,4 +1,5 @@
-import test from "ava";
+import anyTest, { TestInterface } from "ava";
+
 import FDBFactory = require("fake-indexeddb/lib/FDBFactory");
 import * as IDBKeyRange from "fake-indexeddb/lib/FDBKeyRange";
 
@@ -7,30 +8,51 @@ import { WordList } from "@common/types";
 
 import { exampleWordlist } from "./fixtures";
 
-test("storing a file", async (t) => {
+/**
+ * Every test will have access to:
+ *
+ *  - an empty database
+ *  - a Storage instance attached to the empty database
+ *
+ * See: https://github.com/avajs/ava/blob/fd4da2f280679eb5fdb903bac17b2cb4431773b6/docs/recipes/typescript.md#typing-tcontext
+ */
+const test = anyTest as TestInterface<{
+  db: PredictiveTextStudioDexie;
+  storage: Storage;
+}>;
+
+/**
+ * Create a new, empty database, and configured storage for each test case.
+ */
+test.beforeEach((t) => {
   const db = new PredictiveTextStudioDexie({
     indexedDB: new FDBFactory(),
     IDBKeyRange,
   });
-  const storage = new Storage(db);
-  const filename = "ExampleWordlist.xlsx";
+  t.context.db = db;
+  t.context.storage = new Storage(db);
+});
 
+test("storing a file", async (t) => {
+  const db = t.context.db;
+  const storage = t.context.storage;
+
+  // At first, there's nothing in the DB:
   t.is(await db.files.count(), 0);
 
-  await storage.saveFile(filename, exampleWordlist);
-
+  await storage.saveFile("ExampleWordlist.xlsx", exampleWordlist);
+  // Now there's one file in the DB!
   t.is(await db.files.count(), 1);
 });
 
 test("retrieving one file with .fetchAllFiles()", async (t) => {
-  const db = new PredictiveTextStudioDexie({
-    indexedDB: new FDBFactory(),
-    IDBKeyRange,
-  });
-  const storage = new Storage(db);
+  const storage = t.context.storage;
   const filename = "ExampleWordlist.xlsx";
+
+  // Let's store ExampleWordlist!
   await storage.saveFile(filename, exampleWordlist);
 
+  // We should find that it has been stored:
   const files = await storage.fetchAllFiles();
   t.is(files.length, 1);
 
@@ -40,11 +62,7 @@ test("retrieving one file with .fetchAllFiles()", async (t) => {
 });
 
 test("retrieving mulitple files with .fetchAllFiles()", async (t) => {
-  const db = new PredictiveTextStudioDexie({
-    indexedDB: new FDBFactory(),
-    IDBKeyRange,
-  });
-  const storage = new Storage(db);
+  const storage = t.context.storage;
 
   const sources = [
     { name: "ExampleWordlist.xlsx", wordlist: exampleWordlist },


### PR DESCRIPTION
Practically every test in test-storage needs its own, empty PredictiveTextStudio database, alongside a Storage object that uses it. This extracts that into a beforeEach hook so that the following tests are easier to write (less boilerplate).