### PR TITLE
refactor(app): extract .button styles

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -42,21 +42,27 @@ pre, code, samp {
  * Can be applied to either a <button> or <a> element.
  */
 .button {
+  display: inline-block;
   margin: 0 .625em;
   padding: .625rem 1.25rem; /* button--medium size */
   border: 1px solid transparent;
   border-radius: .625rem;
 
-  font-family: var(--main-font), sans-serif;
-  font-size: 1em;
-  font-weight: bold;
+  font: bold 1em var(--main-font), sans-serif;
   text-transform: uppercase;
+  text-decoration: none;
 
   color: var(--default-text-color);
   background-color: var(--lite-white); /* button--grey */
 
   transition-duration: 0.2s;
   cursor: pointer;
+}
+
+/* make <a> .button have a focus ring like <button> elements. */
+a.button:focus {
+  outline: .5rem auto var(--primary-blue);
+  outline-color: -webkit-focus-ring-color;
 }
 
 .button--blue.button--outline:hover,

--- a/public/global.css
+++ b/public/global.css
@@ -60,12 +60,12 @@ pre, code, samp {
   background-color: var(--gray-hover);
 }
 
-.button--grey.outline {
+.button--grey.button--outline {
   border-color: var(--gray-hover);
   background-color: var(--white);
 }
 
-.button--grey.outline:hover {
+.button--grey.button--outline:hover {
   background-color: var(--lite-white);
 }
 
@@ -78,12 +78,12 @@ pre, code, samp {
   background-color: var(--dark-blue);
 }
 
-.button--blue.outline {
+.button--blue.button--outline {
   border-color: var(--primary-blue);
   background-color: var(--white);
   color: var(--primary-blue);
 }
 
-.button--blue.outline:hover {
+.button--blue.button--outline:hover {
   background-color: var(--lite-white);
 }

--- a/public/global.css
+++ b/public/global.css
@@ -52,7 +52,9 @@ pre, code, samp {
   cursor: pointer;
 }
 
-.button--grey {
+.button--grey,
+.button--blue.button--outline:hover,
+.button--grey.button--outline:hover {
   background-color: var(--lite-white);
 }
 
@@ -63,10 +65,6 @@ pre, code, samp {
 .button--grey.button--outline {
   border-color: var(--gray-hover);
   background-color: var(--white);
-}
-
-.button--grey.button--outline:hover {
-  background-color: var(--lite-white);
 }
 
 .button--blue {
@@ -82,8 +80,4 @@ pre, code, samp {
   border-color: var(--primary-blue);
   background-color: var(--white);
   color: var(--primary-blue);
-}
-
-.button--blue.button--outline:hover {
-  background-color: var(--lite-white);
 }

--- a/public/global.css
+++ b/public/global.css
@@ -85,3 +85,15 @@ pre, code, samp {
 .button--shadow {
   box-shadow: 0px 25px 30px rgba(0, 0, 0, 0.15);
 }
+
+.button--small {
+  padding: .3125rem .625rem;
+}
+
+.button--medium {
+  padding: .625rem 1.25rem;
+}
+
+.button--large {
+  padding: .625rem 3.75rem;
+}

--- a/public/global.css
+++ b/public/global.css
@@ -32,3 +32,21 @@ h1, h2, h3, h4, h5, h6 {
 pre, code, samp {
   font-family: var(--mono-font), monospace;
 }
+
+/**
+ * .button Block
+ *
+ * Can be applied to either a <button> or <a> element.
+ */
+.button {
+  margin: 0 .625em;
+  border-radius: .625rem;
+
+  font-family: var(--main-font), sans-serif;
+  font-size: 1em;
+  font-weight: bold;
+  text-transform: uppercase;
+
+  transition-duration: 0.2s;
+  cursor: pointer;
+}

--- a/public/global.css
+++ b/public/global.css
@@ -65,12 +65,6 @@ a.button:focus {
   outline-color: -webkit-focus-ring-color;
 }
 
-.button--blue.button--outline:hover,
-.button--primary.button--outline:hover,
-.button--grey.button--outline:hover {
-  background-color: var(--lite-white);
-}
-
 .button--grey:hover {
   background-color: var(--gray-hover);
 }
@@ -96,6 +90,10 @@ a.button:focus {
   border-color: var(--primary-blue);
   background-color: var(--white);
   color: var(--primary-blue);
+}
+
+.button--outline:hover {
+  background-color: var(--lite-white);
 }
 
 .button--shadow {

--- a/public/global.css
+++ b/public/global.css
@@ -81,3 +81,7 @@ pre, code, samp {
   background-color: var(--white);
   color: var(--primary-blue);
 }
+
+.button--shadow {
+  box-shadow: 0px 25px 30px rgba(0, 0, 0, 0.15);
+}

--- a/public/global.css
+++ b/public/global.css
@@ -50,3 +50,41 @@ pre, code, samp {
   transition-duration: 0.2s;
   cursor: pointer;
 }
+
+.button--grey {
+  background-color: var(--lite-white);
+  border-width: 0px;
+}
+
+.button--grey:hover {
+  background-color: var(--gray-hover);
+}
+
+.button--grey.outline {
+  border: 1px solid var(--gray-hover);
+  background-color: var(--white);
+}
+
+.button--grey.outline:hover {
+  background-color: var(--lite-white);
+}
+
+.button--blue {
+  background-color: var(--primary-blue);
+  border-width: 0px;
+  color: var(--white);
+}
+
+.button--blue:hover {
+  background-color: var(--dark-blue);
+}
+
+.button--blue.outline {
+  border: 1px solid var(--primary-blue);
+  background-color: var(--white);
+  color: var(--primary-blue);
+}
+
+.button--blue.outline:hover {
+  background-color: var(--lite-white);
+}

--- a/public/global.css
+++ b/public/global.css
@@ -40,6 +40,7 @@ pre, code, samp {
  */
 .button {
   margin: 0 .625em;
+  border: 1px solid transparent;
   border-radius: .625rem;
 
   font-family: var(--main-font), sans-serif;
@@ -53,7 +54,6 @@ pre, code, samp {
 
 .button--grey {
   background-color: var(--lite-white);
-  border-width: 0px;
 }
 
 .button--grey:hover {
@@ -61,7 +61,7 @@ pre, code, samp {
 }
 
 .button--grey.outline {
-  border: 1px solid var(--gray-hover);
+  border-color: var(--gray-hover);
   background-color: var(--white);
 }
 
@@ -71,7 +71,6 @@ pre, code, samp {
 
 .button--blue {
   background-color: var(--primary-blue);
-  border-width: 0px;
   color: var(--white);
 }
 
@@ -80,7 +79,7 @@ pre, code, samp {
 }
 
 .button--blue.outline {
-  border: 1px solid var(--primary-blue);
+  border-color: var(--primary-blue);
   background-color: var(--white);
   color: var(--primary-blue);
 }

--- a/public/global.css
+++ b/public/global.css
@@ -54,6 +54,7 @@ pre, code, samp {
 
 .button--grey,
 .button--blue.button--outline:hover,
+.button--primary.button--outline:hover,
 .button--grey.button--outline:hover {
   background-color: var(--lite-white);
 }
@@ -67,16 +68,19 @@ pre, code, samp {
   background-color: var(--white);
 }
 
-.button--blue {
+.button--blue,
+.button--primary {
   background-color: var(--primary-blue);
   color: var(--white);
 }
 
-.button--blue:hover {
+.button--blue:hover,
+.button--primary:hover {
   background-color: var(--dark-blue);
 }
 
-.button--blue.button--outline {
+.button--blue.button--outline,
+.button--primary.button--outline {
   border-color: var(--primary-blue);
   background-color: var(--white);
   color: var(--primary-blue);

--- a/public/global.css
+++ b/public/global.css
@@ -14,6 +14,9 @@
   --white: #ffffff;
   --primary-blue: #0099ff;
   --dark-blue: #0876c0;
+
+  --default-text-color: #000;
+
   /* Font stack */
   /* Custom fonts downloaded from Google Fonts -- see public/index.html */
   --main-font: "Cabin";
@@ -40,6 +43,7 @@ pre, code, samp {
  */
 .button {
   margin: 0 .625em;
+  padding: .625rem 1.25rem; /* button--medium size */
   border: 1px solid transparent;
   border-radius: .625rem;
 
@@ -48,11 +52,13 @@ pre, code, samp {
   font-weight: bold;
   text-transform: uppercase;
 
+  color: var(--default-text-color);
+  background-color: var(--lite-white); /* button--grey */
+
   transition-duration: 0.2s;
   cursor: pointer;
 }
 
-.button--grey,
 .button--blue.button--outline:hover,
 .button--primary.button--outline:hover,
 .button--grey.button--outline:hover {
@@ -92,10 +98,6 @@ pre, code, samp {
 
 .button--small {
   padding: .3125rem .625rem;
-}
-
-.button--medium {
-  padding: .625rem 1.25rem;
 }
 
 .button--large {

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -11,20 +11,6 @@
 </script>
 
 <style>
-  button {
-    margin: 0px 10px;
-    border-radius: 10px;
-    text-transform: uppercase;
-    font-family: Cabin, sans-serif;
-    font-size: 15px;
-    font-weight: bold;
-    transition-duration: 0.2s;
-  }
-
-  button:hover {
-    cursor: pointer;
-  }
-
   .small {
     padding: 5px 10px;
   }
@@ -95,7 +81,7 @@
 
 <div class="button-layout">
   <button
-    class="{color} {size}"
+    class="button {color} {size}"
     class:shadow={hasDropShadow}
     class:outline={isOutlined}
     on:click={onClick}><slot /></button>

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -46,7 +46,7 @@
   <button
     class="button button--{color} {size}"
     class:shadow={hasDropShadow}
-    class:outline={isOutlined}
+    class:button--outline={isOutlined}
     on:click={onClick}><slot /></button>
   {#if subtext}
     <p class="subtext">{subtext}</p>

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -23,11 +23,6 @@
     padding: 10px 60px;
   }
 
-
-  .shadow {
-    box-shadow: 0px 25px 30px rgba(0, 0, 0, 0.15);
-  }
-
   .subtext {
     font-family: var(--mono-font), monospace;
     color: var(--gray);
@@ -45,7 +40,7 @@
 <div class="button-layout">
   <button
     class="button button--{color} {size}"
-    class:shadow={hasDropShadow}
+    class:button--shadow={hasDropShadow}
     class:button--outline={isOutlined}
     on:click={onClick}><slot /></button>
   {#if subtext}

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -23,43 +23,6 @@
     padding: 10px 60px;
   }
 
-  .grey {
-    background-color: var(--lite-white);
-    border-width: 0px;
-  }
-
-  .grey:hover {
-    background-color: var(--gray-hover);
-  }
-
-  .grey.outline {
-    border: 1px solid var(--gray-hover);
-    background-color: var(--white);
-  }
-
-  .grey.outline:hover {
-    background-color: var(--lite-white);
-  }
-
-  .blue {
-    background-color: var(--primary-blue);
-    border-width: 0px;
-    color: var(--white);
-  }
-
-  .blue:hover {
-    background-color: var(--dark-blue);
-  }
-
-  .blue.outline {
-    border: 1px solid var(--primary-blue);
-    background-color: var(--white);
-    color: var(--primary-blue);
-  }
-
-  .blue.outline:hover {
-    background-color: var(--lite-white);
-  }
 
   .shadow {
     box-shadow: 0px 25px 30px rgba(0, 0, 0, 0.15);
@@ -81,7 +44,7 @@
 
 <div class="button-layout">
   <button
-    class="button {color} {size}"
+    class="button button--{color} {size}"
     class:shadow={hasDropShadow}
     class:outline={isOutlined}
     on:click={onClick}><slot /></button>

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -11,18 +11,6 @@
 </script>
 
 <style>
-  .small {
-    padding: 5px 10px;
-  }
-
-  .medium {
-    padding: 10px 20px;
-  }
-
-  .large {
-    padding: 10px 60px;
-  }
-
   .subtext {
     font-family: var(--mono-font), monospace;
     color: var(--gray);
@@ -39,7 +27,7 @@
 
 <div class="button-layout">
   <button
-    class="button button--{color} {size}"
+    class="button button--{color} button--{size}"
     class:button--shadow={hasDropShadow}
     class:button--outline={isOutlined}
     on:click={onClick}><slot /></button>

--- a/src/app/pages/LandingPage.svelte
+++ b/src/app/pages/LandingPage.svelte
@@ -18,7 +18,7 @@
   <section id="explanation">
     <!-- TODO: figure that explains the flow -->
 
-    <a href="#get-started" class="button button--primary">Get started</a>
+    <a href="#get-started" class="button button--primary button--shadow">Get started</a>
   </section>
 
   <section id="get-started" class="quick-start">
@@ -34,13 +34,12 @@
         <Upload />
       </fieldset>
 
-      <button type="submit"> Upload </button>
+      <button class="button button--primary button--shadow" type="submit"> Upload </button>
     </form>
   </section>
 
   <footer>
     <p><small> © 2020 <a href="https://github.com/eddieantonio/predictive-text-studio/graphs/contributors">
-      Eddie Antonio Santos and contributors
-    </a>.</small></p>
+      Eddie Antonio Santos and contributors</a>.</small></p>
   </footer>
 </main>

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -104,7 +104,7 @@
   }
 
   .languages__sidebar {
-    width: 75px;
+    min-width: 75px;
   }
 
   .languages__container {


### PR DESCRIPTION
Extracts most of the `Button` component's styles to regular ol' CSS. This means these styles can be reused in other places, like the `<a>` on the landing page.

I used BEM conventions to create the `button` BLOCK, with a number of MODIFIERS, as authored by @pranavnarang. There are no ELEMENTs to the `button` BLOCK, however the `Button` component still exists, and has a "subtext" attribute that acts like an element of the button.

**EDIT**: I also snuck in a fix to the sidebar. For some reason that eludes me, it wasn't getting its width assigned from `width: 75px`, but `min-width` works ¯\\\_(ツ)\_/¯  

Addresses #98
