### PR TITLE
change(style): always use T[] notation for array types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,8 @@ module.exports = {
   ],
   rules: {
     // Project-speific rules
-    //
-    // For now, there are none!
+
+    // Always prefer T[] instead of Array<T>
+    "@typescript-eslint/array-type": ["error", { default: "array" }],
   },
 };


### PR DESCRIPTION
I keep complaining that `Array<SomeType>` ("generic style") should be written as `SomeType[]` ("array style"). This automatically enforces it, _and_ automatically fixes it too!
