### PR TITLE
change(style): lint error on console.log() statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
   rules: {
     // Project-speific rules
 
+    "no-console": ["error", { allow: ["error", "warn"] }],
     // Always prefer T[] instead of Array<T>
     "@typescript-eslint/array-type": ["error", { default: "array" }],
   },


### PR DESCRIPTION
It's now an error to leave `console.log()` in code that you commit.

We keep making PR comments like "did you mean to leave that in?" with the response being like "it was for debugging". So instead of wasting time in the PRs addressing `console.log()` we can just break the build instead ^.^ 

## Why ban `console.log()`?

Not only is leaving `console.log()` in production kind of sloppy (forgot to remove debug prints) — it actually can cause pretty serious memory leaks! Log messages and anything object logged stay in memory, _even if the dev tools are never opened_ (see: https://cherniavskii.com/be-careful-with-console-logs/#console-warnings).
