### PR TITLE
docs: add references to Airbnb style/our conventions document

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -101,6 +101,14 @@ With the server running as above (with `yarn start`), run this to open
     yarn run cy
 
 
+Coding Conventions
+------------------
+
+Please make sure your PRs follow [our conventions
+document](../docs/conventions.md). Following this guide will prevent
+many unnecessary PR comments!
+
+
 For CANOSP Participants
 -----------------------
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Table of contents
   * [Build](#build)
   * [Start the development environment](#start-the-development-environment)
   * [Run the end-to-end tests interactively](#run-the-end-to-end-tests-interactively)
+- [Coding Conventions](#coding-conventions)
 - [For CANOSP Participants](#for-canosp-participants)
   * [Choose a card](#choose-a-card)
   * [Assign yourself to the issue associated with the card](#assign-yourself-to-the-issue-associated-with-the-card)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -132,6 +132,14 @@ See here:
  - https://softwareengineering.stackexchange.com/a/213685/284069
 
 
+JavaScript: Use Airbnb's Naming Conventions
+-------------------------------------------
+
+When in doubt, consult [Airbnb's JavaScript style
+guide](https://github.com/airbnb/javascript#naming-conventions) for
+naming conventions.
+
+
 CSS: ordering declarations in CSS rulesets
 ------------------------------------------
 


### PR DESCRIPTION
Adds a few references to Airbnb's JavaScript naming conventions and our ow conventions document.
