### PR TITLE
Feat/privacy policy page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ coverage/
 
 .yarn/
 
+.env
+
 # Cypress stuff
 cypress/screenshots/
 cypress/videos/

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -2,6 +2,7 @@
   import { Router, Route } from "svelte-routing";
   import LandingPage from "./pages/LandingPage.svelte";
   import Languages from "./pages/Languages.svelte";
+  import Privacy from "./pages/Privacy.svelte";
 
   // Used for SSR. A falsy value is ignored by the Router.
   export let url = "";
@@ -10,4 +11,5 @@
 <Router {url}>
   <Route path="/" component={LandingPage} />
   <Route path="languages" component={Languages} />
+  <Route path="privacy" component={Privacy} />
 </Router>

--- a/src/app/pages/LandingPage.svelte
+++ b/src/app/pages/LandingPage.svelte
@@ -275,6 +275,8 @@
 <footer class="footer">
   <p class="footer__copyright">
     <small>
+      <a href="/privacy">Privacy Policy</a>
+      <br />
       © 2020
       <a
         href="https://github.com/eddieantonio/predictive-text-studio/graphs/contributors">

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -38,7 +38,7 @@
     <p>
       If you have any questions or comments about this Privacy Policy, please
       contact us at
-      <a href="mailto:easantos@ualberta.ca">easantos@ualberta.ca</a>.
+      <a href="mailto:easantos+ptstudio@ualberta.ca">easantos+ptstudio@ualberta.ca</a>.
     </p>
     <p>
       We are committed to protecting and respecting your privacy. The Privacy

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -163,5 +163,5 @@
         href="http://livechat.com/privacy-policy-generator/?ppg"
         target="_blank">Privacy Policy Generator</a>.
     </p>
-  </div>
+  </article>
 </main>

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -9,10 +9,6 @@
     margin-top: 20px;
   }
 
-  .privacy h1 h2 h3 h4 {
-    font-family: Cabin, sans-serif;
-  }
-
   a {
     text-decoration: none;
   }

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -19,7 +19,7 @@
 </style>
 
 <main>
-  <div class="privacy">
+  <article class="privacy">
     <a href="/"><Button color="blue">Back</Button></a>
     <h2>Predictive Text Studio Privacy Policy</h2>
     <p><strong>Effective as of:</strong> 11/12/2020</p>

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -12,6 +12,14 @@
   a {
     text-decoration: none;
   }
+  article {
+    counter-reset: clause;
+  }
+  
+  article h3::before {
+    counter-increment: clause;
+    content: counter(clause) ". ";
+  }
 </style>
 
 <main>

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -1,0 +1,170 @@
+<script>
+  import Button from "../components/Button.svelte";
+</script>
+
+<style>
+  .privacy {
+    width: 50%;
+    margin: auto;
+    margin-top: 20px;
+  }
+
+  .privacy h1 h2 h3 h4 {
+    font-family: Cabin, sans-serif;
+  }
+
+  a {
+    text-decoration: none;
+  }
+</style>
+
+<main>
+  <div class="privacy">
+    <a href="/"><Button color="blue">Back</Button></a>
+    <h2>Predictive Text Studio Privacy Policy</h2>
+    <p><strong>Effective as of:</strong> 11/12/2020</p>
+    <h3>1. Introduction</h3>
+    <p>
+      These Privacy Policy (“Privacy Policy”) apply to the use of the website
+      and products provided by Predictive Text Stuio (hereinafter also referred
+      as “we” or “us”).
+    </p>
+    <p>
+      This Privacy Policy applies and has effect in respect of all services and
+      other products, software, made available by us, as well as any other
+      online features relating to the website and its content (the
+      “Service(s)”).
+    </p>
+    <p>
+      If you have any questions or comments about this Privacy Policy, please
+      contact us at
+      <a href="mailto:easantos@ualberta.ca">easantos@ualberta.ca</a>.
+    </p>
+    <p>
+      We are committed to protecting and respecting your privacy. The Privacy
+      Policy explains the basis on which personal information we collect from
+      you will be processed by us or on our behalf. Where we decide the purpose
+      or means for which personal data you supply through these Services is
+      processed, we are the “controller”. Where you decide the purpose or means
+      for which personal data you supply through these Services is processed,
+      you are the “controller”. We will comply with proper and applicable data
+      protection laws, including the General Data Protection Regulation
+      2016/679.
+    </p>
+    <p>
+      We encourage you to read this Privacy Policy carefully as it contains
+      important information about the following:
+    </p>
+    <ul>
+      <li>What information we may collect about you;</li>
+      <li>How we will use the information we collect about you;</li>
+      <li>Whether we will disclose your details to anyone else; and</li>
+      <li>
+        Your choices and rights regarding the personal information you have
+        provided to us.
+      </li>
+    </ul>
+    <p>
+      The Services may contain links to services owned and operated by third
+      parties. We may also use some third-parties software or products to
+      provide you with the Service properly. If we do so and provide third
+      -parties of any personal data you can be sure the transfer is legal and
+      secured. These third-party services may have their own privacy policies
+      and we recommend that you review them. They will govern the use of
+      personal information that you submit or which is collected by cookies and
+      other tracking technologies whilst using these services. We do not accept
+      any responsibility or liability for the privacy practices of such third
+      party services and your use of these is at your own risk.
+    </p>
+    <p>
+      We may make changes to this Privacy Policy in the future. You should check
+      this page from time to time to ensure you are aware of any changes. Where
+      appropriate we may notify you of such changes.
+    </p>
+    <h3>2. Information we may collect about you</h3>
+    <p>
+      We do not collect or store any of the data you supply to us while using
+      the Service or website. All data is stored locally on your browser.
+    </p>
+    <h3>3. Collecting, processing and using personal data</h3>
+    <p>We do not store or process any personal data.</p>
+    <h3>4. Why we collect information about you - purpose of processing</h3>
+    <p>
+      We will use information you provide for delivering our Services to you
+      under the terms of use agreed between us. The processing of information in
+      this way is necessary for us to provide you the Service properly and to
+      ensure the features function properly so that you have the best Service
+      possible.
+    </p>
+    <p />
+    <h3>5. Cookies and Web Beacons</h3>
+    <p>We do not use cookies or web beacons.</p>
+    <h3>6. Log files</h3>
+    <p>Log files do not contain any personal data.</p>
+    <p />
+    <h3>7. Children personal data</h3>
+    <p>
+      We do not collect personal information from anyone including those under
+      the age of 18. We encourage parents and legal guardians to monitor their
+      children’s Internet usage and to help enforce this Policy by instructing
+      their children never to provide personal information through the websites
+      or Services.
+    </p>
+    <h3>8. Data sharing</h3>
+    <p>We do not share your data with any third parties.</p>
+    <p>
+      Required by law: We may disclose information to the extent that we are
+      required to do so by law (which may include to government bodies and law
+      enforcement agencies); in connection with any legal proceedings or
+      prospective legal proceedings; and in order to establish, exercise or
+      defend our legal rights.
+    </p>
+    <h3>9. Data transmission</h3>
+    <p>
+      Your data is transmitted safely by using encryption. We secure our website
+      and other systems with technical and organizational measures against the
+      loss, destruction, access, change or dissemination of your data by
+      unauthorized persons.
+    </p>
+    <h3>10. Your rights</h3>
+    <p>
+      You have the following rights over the way your personal data are
+      processed.
+    </p>
+    <p>
+      To make a request, please let us know by sending an email to
+      <a href="mailto:easantos@ualberta.ca">easantos@ualberta.ca</a>.
+    </p>
+    <p>
+      a) You have the right to request a copy of the personal information we
+      process about you and to have any inaccuracies corrected.
+    </p>
+    <p>
+      b) You can ask for supplying, correcting or deleting personal information
+      held about you.
+    </p>
+    <p>
+      c) You can ask us to restrict, stop processing, or to delete your personal
+      data.
+    </p>
+    <p>d) You can withdraw your consent for data processing.</p>
+    <p>
+      e) Obtain a copy of your personal data, which you can use with another
+      service provider.
+    </p>
+    <p>f) Make a complaint to a Supervisory Authority.</p>
+    <h3>11. Changes to this privacy policy</h3>
+    <p>
+      This Privacy Policy may be updated from time to time. We encourage you to
+      review this website for the latest information on our privacy practices.
+      If there are any material changes to this Privacy Policy, you will be
+      notified by posting a notice on the website prior to the change becoming
+      effective. If you do not accept any changes made to this Privacy Policy,
+      please discontinue the use of the website and the Services. This Privacy
+      Policy has been created with the help of
+      <a
+        href="http://livechat.com/privacy-policy-generator/?ppg"
+        target="_blank">Privacy Policy Generator</a>.
+    </p>
+  </div>
+</main>

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -124,7 +124,7 @@
     </p>
     <p>
       To make a request, please let us know by sending an email to
-      <a href="mailto:easantos@ualberta.ca">easantos@ualberta.ca</a>.
+      <a href="mailto:easantos+ptstudio@ualberta.ca">easantos+ptstudio@ualberta.ca</a>.
     </p>
     <p>
       a) You have the right to request a copy of the personal information we

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -23,7 +23,7 @@
     <a href="/"><Button color="blue">Back</Button></a>
     <h2>Predictive Text Studio Privacy Policy</h2>
     <p><strong>Effective as of:</strong> 11/12/2020</p>
-    <h3>1. Introduction</h3>
+    <h3>Introduction</h3>
     <p>
       These Privacy Policy (“Privacy Policy”) apply to the use of the website
       and products provided by Predictive Text Stuio (hereinafter also referred
@@ -81,12 +81,12 @@
       this page from time to time to ensure you are aware of any changes. Where
       appropriate we may notify you of such changes.
     </p>
-    <h3>2. Information we may collect about you</h3>
+    <h3>Information we may collect about you</h3>
     <p>
       We do not collect or store any of the data you supply to us while using
       the Service or website. All data is stored locally on your browser.
     </p>
-    <h3>3. Collecting, processing and using personal data</h3>
+    <h3>Collecting, processing and using personal data</h3>
     <p>We do not store or process any personal data.</p>
     <h3>4. Why we collect information about you - purpose of processing</h3>
     <p>
@@ -97,12 +97,12 @@
       possible.
     </p>
     <p />
-    <h3>5. Cookies and Web Beacons</h3>
+    <h3>Cookies and Web Beacons</h3>
     <p>We do not use cookies or web beacons.</p>
-    <h3>6. Log files</h3>
+    <h3>Log files</h3>
     <p>Log files do not contain any personal data.</p>
     <p />
-    <h3>7. Children personal data</h3>
+    <h3>Children personal data</h3>
     <p>
       We do not collect personal information from anyone including those under
       the age of 18. We encourage parents and legal guardians to monitor their
@@ -110,7 +110,7 @@
       their children never to provide personal information through the websites
       or Services.
     </p>
-    <h3>8. Data sharing</h3>
+    <h3>Data sharing</h3>
     <p>We do not share your data with any third parties.</p>
     <p>
       Required by law: We may disclose information to the extent that we are
@@ -119,14 +119,9 @@
       prospective legal proceedings; and in order to establish, exercise or
       defend our legal rights.
     </p>
-    <h3>9. Data transmission</h3>
-    <p>
-      Your data is transmitted safely by using encryption. We secure our website
-      and other systems with technical and organizational measures against the
-      loss, destruction, access, change or dissemination of your data by
-      unauthorized persons.
-    </p>
-    <h3>10. Your rights</h3>
+    <h3>Data transmission</h3>
+    <p>We do not transmit you data.</p>
+    <h3>Your rights</h3>
     <p>
       You have the following rights over the way your personal data are
       processed.
@@ -153,7 +148,7 @@
       service provider.
     </p>
     <p>f) Make a complaint to a Supervisory Authority.</p>
-    <h3>11. Changes to this privacy policy</h3>
+    <h3>Changes to this privacy policy</h3>
     <p>
       This Privacy Policy may be updated from time to time. We encourage you to
       review this website for the latest information on our privacy practices.

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -88,15 +88,6 @@
     </p>
     <h3>3. Collecting, processing and using personal data</h3>
     <p>We do not store or process any personal data.</p>
-    <h3>4. Why we collect information about you - purpose of processing</h3>
-    <p>
-      We will use information you provide for delivering our Services to you
-      under the terms of use agreed between us. The processing of information in
-      this way is necessary for us to provide you the Service properly and to
-      ensure the features function properly so that you have the best Service
-      possible.
-    </p>
-    <p />
     <h3>5. Cookies and Web Beacons</h3>
     <p>We do not use cookies or web beacons.</p>
     <h3>6. Log files</h3>

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -16,7 +16,9 @@
 
 <main>
   <article class="privacy">
-    <a href="/"><Button color="blue">Back</Button></a>
+    <nav style="text-align: center">
+      <a href="/" class="button button--blue">Back</a>
+    </nav>
     <h2>Predictive Text Studio Privacy Policy</h2>
     <p><strong>Effective as of:</strong> 11/12/2020</p>
     <h3>1. Introduction</h3>


### PR DESCRIPTION
### Add Privacy Policy Page
* Add a privacy policy page with route `/privacy` that can be accessed in the footer
* Modified footer on home page to include route to `/privacy` 
* Please suggest any changes in the content if needed

Resolves #119 


