### PR TITLE
feat(cypress): cy.data() command

### DIFF
--- a/cypress/integration/addSource.spec.ts
+++ b/cypress/integration/addSource.spec.ts
@@ -1,16 +1,14 @@
 describe("Add source feature in LanguageSource page", function () {
   it("should find a button to press to add source by uploading file", function () {
     cy.visit("/languages");
-    cy.get("[data-cy=languages-sources-btn]").contains("Sources").click();
+    cy.data("languages-sources-btn").contains("Sources").click();
 
     // Add source component should show after clicking the details element
-    cy.get("[data-cy=language-sources-add-sources]").click().scrollIntoView();
+    cy.data("language-sources-add-sources").click().scrollIntoView();
 
-    cy.get("[data-cy=add-sources-splitbtn-left]").contains("Upload").click();
-    cy.get("[data-cy=upload-dropzone]").contains("label", "Browse file");
+    cy.data("add-sources-splitbtn-left").contains("Upload").click();
+    cy.data("upload-dropzone").contains("label", "Browse file");
 
-    cy.get("[data-cy=language-sources-add-sources]")
-      .contains("Add Source")
-      .click();
+    cy.data("language-sources-add-sources").contains("Add Source").click();
   });
 });

--- a/cypress/integration/manualEntry.spec.ts
+++ b/cypress/integration/manualEntry.spec.ts
@@ -1,27 +1,25 @@
 describe("", function () {
   it("should find a button to press to add source by user entry manually", function () {
     cy.visit("/languages");
-    cy.get("[data-cy=languages-sources-btn]").contains("Sources").click();
+    cy.data("languages-sources-btn").contains("Sources").click();
 
     // Add source component should show after clicking the details element
-    cy.get("[data-cy=language-sources-add-sources]")
+    cy.data("language-sources-add-sources")
       .contains("Add Source")
       .click()
       .scrollIntoView();
 
-    cy.get("[data-cy=add-sources-splitbtn-right]")
+    cy.data("add-sources-splitbtn-right")
       .contains("Direct entry")
       .click()
       .scrollIntoView();
-    cy.get("[data-cy=manual-entry-input-tablename]").type("Common Greetings");
-    cy.get("[data-cy=manual-entry-input-word]").type("Hello");
-    cy.get("[data-cy=manual-entry-input-count]").type("112");
+    cy.data("manual-entry-input-tablename").type("Common Greetings");
+    cy.data("manual-entry-input-word").type("Hello");
+    cy.data("manual-entry-input-count").type("112");
 
-    cy.get("[data-cy=manual-entry-delete]").contains("Delete").click();
+    cy.data("manual-entry-delete").contains("Delete").click();
     //TODO: Current row should be deleted
 
-    cy.get("[data-cy=language-sources-add-sources]")
-      .contains("Add Source")
-      .click();
+    cy.data("language-sources-add-sources").contains("Add Source").click();
   });
 });

--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -23,7 +23,7 @@ describe("Upload from the the landing page", function () {
 
     const downloadedFilePath = path.join(downloadFolder, "Example.kmp");
 
-    cy.get("[data-cy=quick-start]")
+    cy.data("quick-start")
       .as("quick-start")
       .scrollIntoView()
       .contains("Browse file");
@@ -31,7 +31,7 @@ describe("Upload from the the landing page", function () {
     // Before we upload anything there should be no download link,
     // and no file downloaded in our folder
     cy.get("@quick-start")
-      .get("[data-cy=download-kmp]")
+      .data("download-kmp")
       .as("download-kmp")
       .should("have.attr", "data-download-state", "disabled");
     cy.readFile(downloadedFilePath).should("not.exist");
@@ -45,12 +45,10 @@ describe("Upload from the the landing page", function () {
       const event = { dataTransfer: { files: [testFile] } };
 
       cy.get("@quick-start")
-        .get("[data-cy=upload-dropzone]")
+        .data("upload-dropzone")
         .trigger("dragenter", event);
 
-      cy.get("@quick-start")
-        .get("[data-cy=upload-dropzone]")
-        .trigger("drop", event);
+      cy.get("@quick-start").data("upload-dropzone").trigger("drop", event);
     });
 
     cy.get("@download-kmp")

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -49,3 +49,10 @@ Cypress.Commands.add("disableSmoothScroll", () => {
     document.body.appendChild(node);
   });
 });
+
+/**
+ * Shortcut for cy.get("[data=NAME]")
+ */
+Cypress.Commands.add("data", (dataCy) => {
+  return cy.get(`[data-cy=${dataCy}]`);
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -12,5 +12,15 @@ declare namespace Cypress {
      * cy.disableSmoothScroll()
      */
     disableSmoothScroll(): void;
+
+    /**
+     * Gets an element by its [data-cy] attribute.
+     *
+     * Secretly, `cy.data("NAME")` is a shortcut for `cy.get("[data-cy=NAME]")`.
+     *
+     * Why use [data-cy]?
+     * See: https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
+     */
+    data(dataCy: string): Chainable;
   }
 }


### PR DESCRIPTION
Creates a new Cypress command: `cy.data(dataCy)`. This is a simple shortcut for `cy.get("[data-cy=NAME]")`. I've also changed all existing instances of `cy.get("[data-cy=NAME]")` to `cy.data("NAME")`.

Spun off from [a comment](https://github.com/eddieantonio/predictive-text-studio/pull/136/files#r528016522)
in #136.
