### PR TITLE
[#158] feat: disable button on landing page

### DIFF
--- a/src/app/components/DownloadKMP.svelte
+++ b/src/app/components/DownloadKMP.svelte
@@ -3,25 +3,32 @@
 </script>
 
 <style>
-  .download-link {
+  .download-component--disabled {
+    cursor: not-allowed;
+  }
+  .download-component__link {
     display: block;
     margin-top: 1.5em;
   }
 
-  .download-link--disabled {
+  .download-component__link--disabled {
     color: var(--gray-medium-dark);
-    cursor: not-allowed;
     opacity: 25%;
+    pointer-events: none;
     text-decoration: none;
   }
 </style>
 
-<a
-  href={downloadURL ? downloadURL : '#'}
-  download="Example.kmp"
-  class="download-link"
-  class:download-link--disabled={downloadURL == ''}
-  data-cy="download-kmp"
-  data-download-state={downloadURL ? 'ready' : 'disabled'}>
-  Download KMP Package
-</a>
+<div
+  class="download-component"
+  class:download-component--disabled={downloadURL == ''}>
+  <a
+    href={downloadURL ? downloadURL : '#'}
+    download="Example.kmp"
+    class="download-component__link"
+    class:download-component__link--disabled={downloadURL == ''}
+    data-cy="download-kmp"
+    data-download-state={downloadURL ? 'ready' : 'disabled'}>
+    Download KMP Package
+  </a>
+</div>


### PR DESCRIPTION
# Summary 
Discovered a bug of the current disable issue when I am working on my task so I pull in this quick pr to fix it. This pr is to fix the **disabling bug** for the **download link** on the landing page. Instead of just showing a disabled cursor, now it will also disable user to click on the link and show disable cursor at the same time. 

# Issue 
#158 
