### PR TITLE
[#55] feat: Right-to-left language support

### DIFF
--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -5,7 +5,7 @@
   export let subtext = "";
   export let error = "";
   export let placeholder = "";
-  export let answer: string;
+  export let answer: string | undefined = "ltr";
 </script>
 
 <style>
@@ -45,15 +45,14 @@
 </style>
 
 <div class="input_field mb-m">
-  <h1 dir="{answer}">{answer}</h1>
   {#if label !== ''}
-    <p class:label>{label}</p>
+    <p class:label dir={answer}>{label}</p>
   {/if}
-  <input type="text" {id} bind:value {placeholder} />
+  <input type="text" {id} bind:value {placeholder} dir={answer} />
   {#if error !== ''}
-    <p class:error>{error}</p>
+    <p class:error dir={answer}>{error}</p>
   {/if}
   {#if subtext !== ''}
-    <p class:subtext>{subtext}</p>
+    <p class:subtext dir={answer}>{subtext}</p>
   {/if}
 </div>

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -5,7 +5,8 @@
   export let subtext = "";
   export let error = "";
   export let placeholder = "";
-  export let answer: string | undefined = "ltr";
+  // LanaugeDirection default is set to Left To Right
+  export let languageDirection: string | undefined = "ltr";
 </script>
 
 <style>
@@ -46,13 +47,13 @@
 
 <div class="input_field mb-m">
   {#if label !== ''}
-    <p class:label dir={answer}>{label}</p>
+    <p class:label dir={languageDirection}>{label}</p>
   {/if}
-  <input type="text" {id} bind:value {placeholder} dir={answer} />
+  <input type="text" {id} bind:value {placeholder} dir={languageDirection} />
   {#if error !== ''}
-    <p class:error dir={answer}>{error}</p>
+    <p class:error dir={languageDirection}>{error}</p>
   {/if}
   {#if subtext !== ''}
-    <p class:subtext dir={answer}>{subtext}</p>
+    <p class:subtext dir={languageDirection}>{subtext}</p>
   {/if}
 </div>

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -45,7 +45,7 @@
 </style>
 
 <div class="input_field mb-m">
-  <h1>{answer}</h1>
+  <h1 dir="{answer}">{answer}</h1>
   {#if label !== ''}
     <p class:label>{label}</p>
   {/if}

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -5,6 +5,7 @@
   export let subtext = "";
   export let error = "";
   export let placeholder = "";
+  export let answer: string;
 </script>
 
 <style>
@@ -44,6 +45,7 @@
 </style>
 
 <div class="input_field mb-m">
+  <h1>{answer}</h1>
   {#if label !== ''}
     <p class:label>{label}</p>
   {/if}

--- a/src/app/components/LanguageInfo.svelte
+++ b/src/app/components/LanguageInfo.svelte
@@ -44,16 +44,19 @@
       value={properties.name}
       subtext="BCP49: kwk-latn" />
     <InputField
+      {answer}
       label="Author or Organization"
       id="author"
       value={properties.author}
       subtext="Shortcode: raeanne" />
     <InputField
+      {answer}
       label="Dictionary Name"
       id="dictionaryName"
       value={properties.dictionary_name}
       subtext="Model ID: raeanne.kwk.kwakwala" />
     <InputField
+      {answer}
       label="Copyright"
       id="copyright"
       value={properties.copyright}

--- a/src/app/components/LanguageInfo.svelte
+++ b/src/app/components/LanguageInfo.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import InputField from "./InputField.svelte";
   export let properties: any; // TODO: I am not sure what type to change it to from any
+  export let answer: string;
 </script>
 
 <style>
@@ -37,6 +38,7 @@
 <div class="language__info">
   <div class="language__info-left">
     <InputField
+      {answer}
       label="Language"
       id="language"
       value={properties.name}

--- a/src/app/components/LanguageInfo.svelte
+++ b/src/app/components/LanguageInfo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import InputField from "./InputField.svelte";
   export let properties: any; // TODO: I am not sure what type to change it to from any
-  export let answer: string;
+  export let languageDirection: string;
 </script>
 
 <style>
@@ -38,25 +38,25 @@
 <div class="language__info">
   <div class="language__info-left">
     <InputField
-      {answer}
+      {languageDirection}
       label="Language"
       id="language"
       value={properties.name}
       subtext="BCP49: kwk-latn" />
     <InputField
-      {answer}
+      {languageDirection}
       label="Author or Organization"
       id="author"
       value={properties.author}
       subtext="Shortcode: raeanne" />
     <InputField
-      {answer}
+      {languageDirection}
       label="Dictionary Name"
       id="dictionaryName"
       value={properties.dictionary_name}
       subtext="Model ID: raeanne.kwk.kwakwala" />
     <InputField
-      {answer}
+      {languageDirection}
       label="Copyright"
       id="copyright"
       value={properties.copyright}

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -11,7 +11,7 @@
 
   export let selectedButton: string = "information";
   export let selectedLanguage: string = "Kwakwala";
-  let answer = writingDictrection.LeftToRight;
+  let languageDirection = writingDictrection.LeftToRight;
 
   // Mock language data object - this would be read from localstorage/db
   export let languageInformation = {
@@ -91,9 +91,9 @@
    */
   const handleDownload = (): void => {};
 
-  const toggleWritingDirection= (): void => {
-    answer =
-      answer == writingDictrection.RightToLeft
+  const toggleWritingDirection = (): void => {
+    languageDirection =
+      languageDirection == writingDictrection.RightToLeft
         ? writingDictrection.LeftToRight
         : writingDictrection.RightToLeft;
   };
@@ -209,12 +209,11 @@
         <Button
           color="blue"
           onClick={toggleWritingDirection}
-          dataCy="languages-download-btn"
         >Toggle Writing Direction</Button>
       </div>
       <div class="languages__container--content">
         {#if selectedButton === 'information'}
-          <LanguageInfo answer="{answer}" properties={languageInformation.properties} />
+          <LanguageInfo languageDirection={languageDirection} properties={languageInformation.properties} />
         {:else if selectedButton === 'sources'}
           <LanguageSources sources={languageInformation.sources} />
         {/if}

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -6,7 +6,7 @@
 
   export let selectedButton: string = "information";
   export let selectedLanguage: string = "Kwakwala";
-  let answer = "22";
+  let answer = "ltr";
 
   // Mock language data object - this would be read from localstorage/db
   export let languageInformation = {
@@ -87,7 +87,7 @@
   const handleDownload = (): void => {};
 
   const toggleDireftion = (): void => {
-    answer = "qq";
+    answer = "rtl";
   };
 </script>
 

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -6,6 +6,7 @@
 
   export let selectedButton: string = "information";
   export let selectedLanguage: string = "Kwakwala";
+  let answer = "22";
 
   // Mock language data object - this would be read from localstorage/db
   export let languageInformation = {
@@ -84,6 +85,10 @@
    * @return {void}
    */
   const handleDownload = (): void => {};
+
+  const toggleDireftion = (): void => {
+    answer = "qq";
+  };
 </script>
 
 <style>
@@ -193,10 +198,15 @@
           subtext={languageInformation.wordCount.toString() + " words"}
           dataCy="languages-download-btn"
         >Download</Button>
+        <Button
+          color="blue"
+          onClick={toggleDireftion}
+          dataCy="languages-download-btn"
+        >Hello</Button>
       </div>
       <div class="languages__container--content">
         {#if selectedButton === 'information'}
-          <LanguageInfo properties={languageInformation.properties} />
+          <LanguageInfo answer="{answer}" properties={languageInformation.properties} />
         {:else if selectedButton === 'sources'}
           <LanguageSources sources={languageInformation.sources} />
         {/if}

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -4,9 +4,14 @@
   import Sidebar from "../components/Sidebar.svelte";
   import Button from "../components/Button.svelte";
 
+  enum writingDictrection {
+    LeftToRight = "ltr",
+    RightToLeft = "rtl",
+  }
+
   export let selectedButton: string = "information";
   export let selectedLanguage: string = "Kwakwala";
-  let answer = "ltr";
+  let answer = writingDictrection.LeftToRight;
 
   // Mock language data object - this would be read from localstorage/db
   export let languageInformation = {
@@ -86,8 +91,11 @@
    */
   const handleDownload = (): void => {};
 
-  const toggleDireftion = (): void => {
-    answer = "rtl";
+  const toggleWritingDirection= (): void => {
+    answer =
+      answer == writingDictrection.RightToLeft
+        ? writingDictrection.LeftToRight
+        : writingDictrection.RightToLeft;
   };
 </script>
 
@@ -200,9 +208,9 @@
         >Download</Button>
         <Button
           color="blue"
-          onClick={toggleDireftion}
+          onClick={toggleWritingDirection}
           dataCy="languages-download-btn"
-        >Hello</Button>
+        >Toggle Writing Direction</Button>
       </div>
       <div class="languages__container--content">
         {#if selectedButton === 'information'}


### PR DESCRIPTION
# Summary
This PR is to adding the toggle functionality to support Right-to-left languages. Currently user is allowed to manually switch between the language direction. 

- Added button on the language page for the toggling named "Toggle Writing Direction", please let me know if there a better name and I tried my best to spell language correctly this time 😂

## Subtasks
- [x] investigate the return Keyman object
**Finding**: Investigated the returning object from Keyman api service and it does provide the information if a language is from LTR and vice versa. This would require the data provided in indexedDB, which it is currently building for [#147](https://github.com/eddieantonio/predictive-text-studio/issues/147). As the description mention a switch between left-to-right and right-to-left would satisfy this issue and another task is created [#160](https://github.com/eddieantonio/predictive-text-studio/issues/160) to further refine the feature to build an automated switching based on the language preference. 
- [x] toggle for LTR or RTL

## Issue
Resolves #55 
