### PR TITLE
[#163] feat: Remove "Projects" sidebar

### DIFF
--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -157,10 +157,6 @@
  -->
 <main>
   <div class="languages">
-    <div class="languages__sidebar">
-      <Sidebar {languages} {selectedLanguage} />
-    </div>
-
     <div class="languages__container">
       <header class="languages__container--header">
         <div>


### PR DESCRIPTION
# Summary 
This pr is to remove side bar component from the language page. I am not sure if we might need this component in the future, hence, I did not delete the `Sidebar.svelte` component from the codebase. 

### Issue
Fixes #163 

