### PR TITLE
[#168] feat: Remove placeholder data

### DIFF
--- a/cypress/integration/bcp47Tag.spec.ts
+++ b/cypress/integration/bcp47Tag.spec.ts
@@ -10,21 +10,19 @@ describe("BCP47Tag component test cases", function () {
       .invoke("attr", "placeholder")
       .should("contain", "Enter the BCP 47 Tag");
     cy.data("tag-input").type("zh");
-    cy.contains("p", "Invalid BCP 47 Tag").should("not.exist");
+    cy.data("input-error-message").should("not.exist");
   });
 
   it("should show error message when invalid tag is given", () => {
     cy.data("tag-input").scrollIntoView().should("be.visible");
     cy.data("tag-input").type("012345");
-    cy.contains("p", "Invalid BCP 47 Tag");
+    cy.data("input-error-message").should("contain", "Invalid BCP 47 Tag");
   });
 
   it("should clears error message when valid tag is given", () => {
     cy.data("tag-input").scrollIntoView().should("be.visible");
     cy.data("tag-input").type("012345");
-    cy.contains("p", "Invalid BCP 47 Tag");
-
     cy.data("tag-input").clear();
-    cy.contains("p", "Invalid BCP 47 Tag").should("not.exist");
+    cy.data("input-error-message").should("not.exist");
   });
 });

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -4,16 +4,17 @@
   import worker from "../spawn-worker";
 
   const TAG_INPUT_ID = "tag-input";
-
-  $: tag = "";
-  $: schema = bcp47.parse(tag);
-  $: validTag = tag === "" || (tag.length > 0 && schema.language !== null);
-  $: error = validTag ? "" : "Invalid BCP 47 Tag";
-  $: if (validTag) {
-    worker.setProjectData({ languages: [{ name: "", id: tag }] });
-  }
+  let errorMessage: string = ""
+  
   function onInputValue(event: CustomEvent) {
-    console.log(event.detail.value)
+    const inputValue = event.detail.value
+    const schema = bcp47.parse(inputValue);
+    if (inputValue.length > 0 && schema.language !== null) {
+      errorMessage = ""
+      worker.setProjectData({ languages: [{ name: "", id: inputValue }] });
+    } else {
+      errorMessage = "Invalid BCP 47 Tag"
+    }
   }
 </script>
 
@@ -23,6 +24,5 @@
   size="large"
   cyData="tag-input"
   label="Step 1: Enter your languages"
-  bind:value={tag}
-  bind:error
+  error={errorMessage}
   placeholder={'Enter the BCP 47 Tag'} />

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -4,7 +4,7 @@
   import worker from "../spawn-worker";
 
   let errorMessage: string = "";
-  
+
   function onInputValue(event: CustomEvent) {
     const inputValue = event.detail.value;
     const schema = bcp47.parse(inputValue);

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -12,9 +12,13 @@
   $: if (validTag) {
     worker.setProjectData({ languages: [{ name: "", id: tag }] });
   }
+  function onInputValue(event: CustomEvent) {
+    console.log(event.detail.value)
+  }
 </script>
 
 <InputField
+  on:messageOnChange={onInputValue}
   id={TAG_INPUT_ID}
   size="large"
   cyData="tag-input"

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -11,6 +11,8 @@
     if (inputValue.length > 0 && schema.language !== null) {
       errorMessage = "";
       worker.setProjectData({ languages: [{ name: "", id: inputValue }] });
+    } else if (inputValue.length == 0) {
+      errorMessage = "";
     } else {
       errorMessage = "Invalid BCP 47 Tag";
     }

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -3,9 +3,8 @@
   import * as bcp47 from "bcp-47";
   import worker from "../spawn-worker";
 
-  const TAG_INPUT_ID = "tag-input";
   let errorMessage: string = "";
-
+  
   function onInputValue(event: CustomEvent) {
     const inputValue = event.detail.value;
     const schema = bcp47.parse(inputValue);
@@ -20,7 +19,7 @@
 
 <InputField
   on:messageOnChange={onInputValue}
-  id={TAG_INPUT_ID}
+  id="tag-input"
   size="large"
   cyData="tag-input"
   label="Step 1: Enter your languages"

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -4,16 +4,16 @@
   import worker from "../spawn-worker";
 
   const TAG_INPUT_ID = "tag-input";
-  let errorMessage: string = ""
-  
+  let errorMessage: string = "";
+
   function onInputValue(event: CustomEvent) {
-    const inputValue = event.detail.value
+    const inputValue = event.detail.value;
     const schema = bcp47.parse(inputValue);
     if (inputValue.length > 0 && schema.language !== null) {
-      errorMessage = ""
+      errorMessage = "";
       worker.setProjectData({ languages: [{ name: "", id: inputValue }] });
     } else {
-      errorMessage = "Invalid BCP 47 Tag"
+      errorMessage = "Invalid BCP 47 Tag";
     }
   }
 </script>

--- a/src/app/components/BCP47Tag.svelte
+++ b/src/app/components/BCP47Tag.svelte
@@ -5,7 +5,7 @@
 
   let errorMessage: string = "";
 
-  function onInputValue(event: CustomEvent) {
+  function validateAndSetLanguage(event: CustomEvent) {
     const inputValue = event.detail.value;
     const schema = bcp47.parse(inputValue);
     if (inputValue.length > 0 && schema.language !== null) {
@@ -20,7 +20,7 @@
 </script>
 
 <InputField
-  on:messageOnChange={onInputValue}
+  on:keytyped={validateAndSetLanguage}
   id="tag-input"
   size="large"
   cyData="tag-input"

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -9,12 +9,11 @@
   export let size: string | undefined = "";
   export let cyData: string | undefined = "";
   export let id: string;
-  export let value: any;
   export let subtext: string = "";
   export let fullWidth: boolean = false;
   export let error: string = "";
   export let placeholder: string = "";
-
+  let inputValue: string = "";
   const dispatch = createEventDispatcher();
 
   function dispatchInputValue(event: Event) {
@@ -22,7 +21,7 @@
     const cleanId = target.id.split("-").pop();
     dispatch("message", {
       key: cleanId,
-      value: value,
+      value: inputValue,
     });
   }
 
@@ -31,7 +30,7 @@
     const cleanId = target.id.split("-").pop();
     dispatch("messageOnChange", {
       key: cleanId,
-      value: value,
+      value: inputValue,
     });
   }
 </script>
@@ -94,13 +93,13 @@
     id="input-{id}"
     {placeholder}
     data-cy={cyData}
-    bind:value
+    bind:value={inputValue}
     on:blur={dispatchInputValue}
     on:input={dispatchInputValueOnInput} />
   {#if error !== ''}
     <p class:error>{error}</p>
   {/if}
   {#if subtext !== ''}
-    <p class="input-field__subtext">{subtext}</p>
+    <p class="input-field__subtext">{subtext}: {inputValue}</p>
   {/if}
 </div>

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -28,7 +28,7 @@
   function dispatchInputValueOnInput(event: Event) {
     const target = event.target as HTMLTextAreaElement;
     const cleanId = target.id.split("-").pop();
-    dispatch("messageOnChange", {
+    dispatch("keytyped", {
       key: cleanId,
       value: inputValue,
     });

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -97,7 +97,7 @@
     on:blur={dispatchInputValue}
     on:input={dispatchInputValueOnInput} />
   {#if error !== ''}
-    <p class:error>{error}</p>
+    <p class:error data-cy="input-error-message">{error}</p>
   {/if}
   {#if subtext !== ''}
     <p class="input-field__subtext">{subtext}: {inputValue}</p>

--- a/src/app/components/InputField.svelte
+++ b/src/app/components/InputField.svelte
@@ -25,6 +25,15 @@
       value: value,
     });
   }
+
+  function dispatchInputValueOnInput(event: Event) {
+    const target = event.target as HTMLTextAreaElement;
+    const cleanId = target.id.split("-").pop();
+    dispatch("messageOnChange", {
+      key: cleanId,
+      value: value,
+    });
+  }
 </script>
 
 <style>
@@ -86,7 +95,8 @@
     {placeholder}
     data-cy={cyData}
     bind:value
-    on:blur={dispatchInputValue} />
+    on:blur={dispatchInputValue}
+    on:input={dispatchInputValueOnInput} />
   {#if error !== ''}
     <p class:error>{error}</p>
   {/if}

--- a/src/app/components/LanguageInfo.svelte
+++ b/src/app/components/LanguageInfo.svelte
@@ -50,18 +50,15 @@
       on:message={updateMetadata}
       label="Author or Organization"
       id="authorName"
-      value=""
-      subtext="Shortcode: raeanne" />
+      subtext="Shortcode" />
     <InputField
       label="Dictionary Name"
       id="dictionaryName"
-      value={properties.dictionary_name}
-      subtext="Model ID: raeanne.kwk.kwakwala" />
+      subtext="Model ID" />
     <InputField
       on:message={updateMetadata}
       label="Copyright"
       id="copyright"
-      value=""
       subtext="" />
   </div>
   <div class="language__info-right">

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -14,10 +14,6 @@
       );
     },
     properties: {
-      name: "Kwakwala",
-      author: "Rae Anne",
-      dictionary_name: "Kwakwala",
-      copyright: "Rae Anne 2020",
       keyboard_image:
         "https://media.idownloadblog.com/wp-content/uploads/2017/02/iOS-10-Keyboard.jpg",
     },

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import LanguageInfo from "../components/LanguageInfo.svelte";
   import LanguageSources from "../components/LanguageSources.svelte";
-  import Sidebar from "../components/Sidebar.svelte";
   import Button from "../components/Button.svelte";
   export let selectedButton: string = "information";
 


### PR DESCRIPTION
# Summary 
This pr is to remove placeholder values for the author's name, word count, and copyright as well as enhancing the input field by adding the feature dynamically update the subtext when user input. 
By leveraging the feature build in [#147](https://github.com/eddieantonio/predictive-text-studio/pull/169) it allows this pr to further simplify the logic in `src/app/components/BCP47Tag.svelte` by relying a more reusable component where child component is now able to communicate with parents components. 

**Note**: this pr has dependency on [#147](https://github.com/eddieantonio/predictive-text-studio/pull/169) because I needed the feature built in #147 to fix `BCP47Tag.svelte component`. The pr review order should ideally in the sequence of [#147](https://github.com/eddieantonio/predictive-text-studio/pull/169)> [This PR](https://github.com/eddieantonio/predictive-text-studio/pull/177) > [#165](https://github.com/eddieantonio/predictive-text-studio/pull/178). Feel free to ping me if there is any questions ☺️

Feel free to ping me if there is any questions ☺️

## Sub-tasks 
- [x] Remove placeholder data
- [x] Fix BCP47Tag.svelte component
- [x] Add dynamic value binding to input 
- [x] Remove used code
- [x] Update existing e2e test
 
## Issue
Resolves #168 