### PR TITLE
fix: upload integration test

### DIFF
--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -40,14 +40,13 @@ describe("Upload from the the landing page", function () {
     cy.fixture(filename, "base64").then((fixture) => {
       const testFile = new File(
         [Cypress.Blob.base64StringToBlob(fixture)],
-        name
+        filename
       );
       const event = { dataTransfer: { files: [testFile] } };
 
       cy.get("@quick-start")
         .data("upload-dropzone")
         .trigger("dragenter", event);
-
       cy.get("@quick-start").data("upload-dropzone").trigger("drop", event);
     });
 

--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -1,9 +1,9 @@
 import "cypress-file-upload";
 
-const path = require("path");
+import path = require("path");
 
 describe("Upload from the the landing page", function () {
-  let downloadFolder;
+  let downloadFolder: string;
 
   before(() => {
     downloadFolder = Cypress.env("downloadFolder");
@@ -16,15 +16,16 @@ describe("Upload from the the landing page", function () {
     cy.disableSmoothScroll();
   });
 
-  // TODO: fix this test
-  it.skip("should find a button to press to upload a file", function () {
-    // we need a valid bcp47Tag to update the packageInfo
+  it("should find a button to press to upload a file", function () {
+    // HACK: wait for the language list to populate
     cy.wait(3000);
-    cy.data("autocomplete-label").type("z");
-    cy.data("autocomplete__suggestion-list")
-      .should("be.visible")
-      .trigger("mouseover");
-    cy.data("autocomplete-suggestions").first().click();
+
+    cy.data("download-kmp")
+      .as("download-kmp")
+      .should("have.attr", "data-download-state", "disabled");
+
+    // Select the first option (should be Straits Salish)
+    cy.data("autocomplete-label").type("straits").type("{enter}");
 
     const downloadedFilePath = path.join(downloadFolder, "Example.kmp");
 

--- a/src/app/pages/LandingPage.svelte
+++ b/src/app/pages/LandingPage.svelte
@@ -3,6 +3,7 @@
   import worker from "../spawn-worker";
   import GoogleSheetsInput from "../components/GoogleSheetsInput.svelte";
   import LanguageNameInput from "../components/LanguageNameInput.svelte";
+  import DownloadKMP from "../components/DownloadKMP.svelte";
   import SplitButton from "../components/SplitButton.svelte";
   import { currentDownloadURL } from "../stores";
 
@@ -337,11 +338,13 @@
       {/if}
       <div class="quick-start__submit-wrapper"
            class:quick-start__submit-wrapper--disabled={!continueReady}>
+        <DownloadKMP downloadURL={$currentDownloadURL} />
+        <p> or </p>
         <button
               class="button button--primary button--shadow quick-start__submit-button"
               class:quick-start__submit-button--disabled={!continueReady}
               type="submit"
-              data-cy="landing-page-continue-button"> Continue
+              data-cy="landing-page-continue-button"> Customize
         </button>
     </div>
 


### PR DESCRIPTION
The `upload.spec.ts` test case was disabled due to the download button being removed from the landing page. Although the landing page should be simplified, the upload test is super important, so I figured it's worth making the landing page a bit sloppy while we figure out where the download button should actually go!
