### PR TITLE
Feat/create "source type" union in @common/types; store in DB

### DIFF
--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -19,7 +19,7 @@
    */
   const handleDelete = (): void => {};
 
-  const dict = {
+  const englishNameOf = {
     "direct-entry": "Direct entry",
     "google-sheets": "Google Sheets",
     tsv: "TSV",
@@ -108,7 +108,7 @@
       <tr>
         <td>{source.name}</td>
         <td>{source.size}</td>
-        <td>{dict[source.type]}</td>
+        <td>{englishNameOf[source.type]}</td>
         <td class="table__row--actions actions">
           <button
             class="actions__action btn--inline"

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -18,6 +18,13 @@
    * @return {void}
    */
   const handleDelete = (): void => {};
+
+  const dict = {
+    "direct-entry": "Direct entry",
+    "google-sheets": "Google Sheets",
+    tsv: "TSV",
+    xlsx: ".xlsx",
+  };
 </script>
 
 <style>
@@ -101,7 +108,7 @@
       <tr>
         <td>{source.name}</td>
         <td>{source.size}</td>
-        <td>{source.type}</td>
+        <td>{dict[source.type]}</td>
         <td class="table__row--actions actions">
           <button
             class="actions__action btn--inline"

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -17,6 +17,15 @@ export type WordAndCount = [string, number];
 export type WordList = WordAndCount[];
 
 /**
+ * A dictionary source type.
+ */
+export type DictionarySourceType =
+  | "xlsx"
+  | "google-sheets"
+  | "tsv"
+  | "direct-entry";
+
+/**
  * A word list stored in the database.
  */
 export interface WordListSource {
@@ -35,7 +44,7 @@ export interface WordListSource {
   /**
    * Type of the file e.g. xlsx
    */
-  type?: string;
+  type: DictionarySourceType;
 }
 
 /**

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -8,7 +8,7 @@ import { readExcel, readManualEntryData, readTSV } from "./read-wordlist";
 import { PredictiveTextStudioWorker } from "@common/predictive-text-studio-worker";
 import { linkStorageToKmp } from "./link-storage-to-kmp";
 import Storage from "./storage";
-import { WordList } from "@common/types";
+import { WordList, DictionarySourceType } from "@common/types";
 import { RelevantKmpOptions } from "@common/kmp-json-file";
 import { DictionaryEntry, ProjectMetadata } from "@common/types";
 
@@ -66,7 +66,12 @@ export class PredictiveTextStudioWorkerImpl
     name: string,
     wordlist: WordList
   ): Promise<ArrayBuffer> {
-    this.storage.saveFile({ name, wordlist, size: wordlist.length });
+    this.storage.saveFile({
+      name,
+      wordlist,
+      size: wordlist.length,
+      type: "google-sheets",
+    });
     return await linkStorageToKmp(this.storage);
   }
 
@@ -91,6 +96,7 @@ export class PredictiveTextStudioWorkerImpl
     contents: File
   ): Promise<number> {
     let wordlist: WordList = [];
+    let type: DictionarySourceType;
     if (/\.(tsv)$/i.test(name)) {
       // Read the file as a string
       const TSVFileString: string = await new Promise((resolve, reject) => {
@@ -105,12 +111,19 @@ export class PredictiveTextStudioWorkerImpl
         reader.readAsText(contents);
       });
       wordlist = readTSV(TSVFileString);
+      type = "tsv" as DictionarySourceType;
     } else if (/\.(xlsx)$/i.test(name)) {
       wordlist = await readExcel(await contents.arrayBuffer());
+      type = "xlsx" as DictionarySourceType;
     } else {
       throw new Error("Invalid File Type. Please use either .tsv or .xlsx");
     }
-    await this.storage.saveFile({ name, wordlist, size: wordlist.length });
+    await this.storage.saveFile({
+      name,
+      wordlist,
+      size: wordlist.length,
+      type,
+    });
     this.generateKMPFromStorage();
     return wordlist.length;
   }
@@ -125,6 +138,7 @@ export class PredictiveTextStudioWorkerImpl
       name: dictionaryName,
       wordlist,
       size: wordlist.length,
+      type: "direct-entry",
     });
     return wordlist.length;
   }

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -111,10 +111,10 @@ export class PredictiveTextStudioWorkerImpl
         reader.readAsText(contents);
       });
       wordlist = readTSV(TSVFileString);
-      type = "tsv" as DictionarySourceType;
+      type = "tsv";
     } else if (/\.(xlsx)$/i.test(name)) {
       wordlist = await readExcel(await contents.arrayBuffer());
-      type = "xlsx" as DictionarySourceType;
+      type = "xlsx";
     } else {
       throw new Error("Invalid File Type. Please use either .tsv or .xlsx");
     }

--- a/test/test-storage.ts
+++ b/test/test-storage.ts
@@ -5,7 +5,7 @@ import * as IDBKeyRange from "fake-indexeddb/lib/FDBKeyRange";
 
 import Storage, { PredictiveTextStudioDexie } from "@worker/storage";
 import { StoredWordList } from "@worker/storage-models";
-import { WordList } from "@common/types";
+import { WordList, DictionarySourceType } from "@common/types";
 
 import { exampleWordlist, keymanKeyboardDataStub } from "./fixtures";
 
@@ -44,6 +44,7 @@ test("storing a file", async (t) => {
     name: "ExampleWordlist.xlsx",
     wordlist: exampleWordlist,
     size: exampleWordlist.length,
+    type: "xlsx" as DictionarySourceType,
   });
   // Now there's one file in the DB!
   t.is(await db.files.count(), 1);
@@ -58,6 +59,7 @@ test("retrieving one file with .fetchAllFiles()", async (t) => {
     name: filename,
     wordlist: exampleWordlist,
     size: exampleWordlist.length,
+    type: "xlsx" as DictionarySourceType,
   });
 
   // We should find that it has been stored:
@@ -77,11 +79,13 @@ test("retrieving mulitple files with .fetchAllFiles()", async (t) => {
       name: "ExampleWordlist.xlsx",
       wordlist: exampleWordlist,
       size: exampleWordlist.length,
+      type: "xlsx" as DictionarySourceType,
     },
     {
       name: "[direct entry]",
       wordlist: [["ȻNEs", 12]] as WordList,
       size: 1,
+      type: "direct-entry" as DictionarySourceType,
     },
   ];
 
@@ -96,11 +100,12 @@ test("retrieving mulitple files with .fetchAllFiles()", async (t) => {
 
   // This weird line extracts ONLY the properties found in sources,
   // so that we can just deepEqual with sources!
-  files = files.map(({ id, name, wordlist, size }) => ({
+  files = files.map(({ id, name, wordlist, size, type }) => ({
     id,
     name,
     wordlist,
     size,
+    type,
   }));
   files.sort(byName);
 

--- a/test/test-storage.ts
+++ b/test/test-storage.ts
@@ -5,7 +5,7 @@ import * as IDBKeyRange from "fake-indexeddb/lib/FDBKeyRange";
 
 import Storage, { PredictiveTextStudioDexie } from "@worker/storage";
 import { StoredWordList } from "@worker/storage-models";
-import { WordListSource, DictionarySourceType } from "@common/types";
+import { WordListSource } from "@common/types";
 
 import { exampleWordlist, keymanKeyboardDataStub } from "./fixtures";
 
@@ -44,7 +44,7 @@ test("storing a file", async (t) => {
     name: "ExampleWordlist.xlsx",
     wordlist: exampleWordlist,
     size: exampleWordlist.length,
-    type: "xlsx" as DictionarySourceType,
+    type: "xlsx",
   });
   // Now there's one file in the DB!
   t.is(await db.files.count(), 1);
@@ -59,7 +59,7 @@ test("retrieving one file with .fetchAllFiles()", async (t) => {
     name: filename,
     wordlist: exampleWordlist,
     size: exampleWordlist.length,
-    type: "xlsx" as DictionarySourceType,
+    type: "xlsx",
   });
 
   // We should find that it has been stored:

--- a/test/test-storage.ts
+++ b/test/test-storage.ts
@@ -5,7 +5,7 @@ import * as IDBKeyRange from "fake-indexeddb/lib/FDBKeyRange";
 
 import Storage, { PredictiveTextStudioDexie } from "@worker/storage";
 import { StoredWordList } from "@worker/storage-models";
-import { WordList, DictionarySourceType } from "@common/types";
+import { WordListSource, DictionarySourceType } from "@common/types";
 
 import { exampleWordlist, keymanKeyboardDataStub } from "./fixtures";
 
@@ -74,18 +74,18 @@ test("retrieving one file with .fetchAllFiles()", async (t) => {
 test("retrieving mulitple files with .fetchAllFiles()", async (t) => {
   const { storage } = t.context;
 
-  const sources = [
+  const sources: WordListSource[] = [
     {
       name: "ExampleWordlist.xlsx",
       wordlist: exampleWordlist,
       size: exampleWordlist.length,
-      type: "xlsx" as DictionarySourceType,
+      type: "xlsx",
     },
     {
       name: "[direct entry]",
-      wordlist: [["ȻNEs", 12]] as WordList,
+      wordlist: [["ȻNEs", 12]],
       size: 1,
-      type: "direct-entry" as DictionarySourceType,
+      type: "direct-entry",
     },
   ];
 


### PR DESCRIPTION
- Define `type DictionarySourceType` in `@common/types`:
```js
type DictionarySourceType = "xlsx" | "google-sheets" | "tsv" | "direct-entry";
```
- Add `type` as `DictionarySourceType` in `WordListSource`

Resolves #235 

**Note:**
- Tested with `.xlsx` and `tsv`. Direct entry and Google Sheets need to be tested further once they are functional.

![Screen Shot 2021-02-12 at 11 00 35 PM](https://user-images.githubusercontent.com/28884850/107844375-a7504400-6d87-11eb-92e8-c2c78494cc84.png)

