### PR TITLE
test: read the contents of the KMP in Cypress tests

### DIFF
--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -54,14 +54,9 @@ describe("Upload from the the landing page", function () {
       .should("have.attr", "data-download-state", "ready")
       .click();
 
-    cy.readFile(downloadedFilePath, "binary")
-      .then((contents) => {
-        const JSZip = require("jszip");
-        return JSZip.loadAsync(contents);
-      })
-      .then((zip) => {
-        expect(zip.file("kmp.json")).to.not.be.null;
-        expect(zip.file(/[.]js$/)).to.have.lengthOf(1);
-      });
+    cy.readZip(downloadedFilePath).then((zip) => {
+      expect(zip.file("kmp.json")).to.not.be.null;
+      expect(zip.file(/[.]js$/)).to.have.lengthOf(1);
+    });
   });
 });

--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -54,6 +54,14 @@ describe("Upload from the the landing page", function () {
       .should("have.attr", "data-download-state", "ready")
       .click();
 
-    cy.readFile(downloadedFilePath);
+    cy.readFile(downloadedFilePath, "binary")
+      .then((contents) => {
+        const JSZip = require("jszip");
+        return JSZip.loadAsync(contents);
+      })
+      .then((zip) => {
+        expect(zip.file("kmp.json")).to.not.be.null;
+        expect(zip.file(/[.]js$/)).to.have.lengthOf(1);
+      });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,5 @@
+const JSZip = require("jszip");
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -62,7 +64,6 @@ Cypress.Commands.add("data", (dataCy) => {
  */
 Cypress.Commands.add("readZip", (filename) => {
   return cy.readFile(filename, "binary").then((contents) => {
-    const JSZip = require("jszip");
     return JSZip.loadAsync(contents);
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -56,3 +56,13 @@ Cypress.Commands.add("disableSmoothScroll", () => {
 Cypress.Commands.add("data", (dataCy) => {
   return cy.get(`[data-cy=${dataCy}]`);
 });
+
+/**
+ * Shortcut for cy.get("[data=NAME]")
+ */
+Cypress.Commands.add("readZip", (filename) => {
+  return cy.readFile(filename, "binary").then((contents) => {
+    const JSZip = require("jszip");
+    return JSZip.loadAsync(contents);
+  });
+});

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,3 +1,10 @@
+/**
+ * Declares the typing of custom commands
+ * See cypress/support/commands.js for the implementations.
+ */
+
+import JSZip = require("jszip");
+
 declare namespace Cypress {
   interface Chainable {
     /**
@@ -5,8 +12,9 @@ declare namespace Cypress {
      * folder, without an "are you sure?" prompt appearing.
      */
     allowUnlimitedDownloadsToFolder(downloadFolder: string): void;
+
     /**
-     * Disable css smooth scroll to avoid using "{ force:true }" in .type.
+     * Disable CSS smooth scroll to avoid using "{ force:true }" in .type.
      * See https://github.com/cypress-io/cypress/issues/3200
      * @example
      * cy.disableSmoothScroll()
@@ -22,5 +30,10 @@ declare namespace Cypress {
      * See: https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements
      */
     data(dataCy: string): Chainable;
+
+    /**
+     * Read a .zip file (or a .kmp file) from the downloads folder.
+     */
+    readZip(filename: string): Promise<JSZip>;
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^8.2.0",
     "exceljs": "~3.5.0",
     "googleapis": "^61.0.0",
-    "jszip": "^3.5.0",
+    "jszip": "^3.6.0",
     "simple-svelte-autocomplete": "^1.2.4",
     "svelte-routing": "^1.4.2",
     "tslib": "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,10 +2704,20 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jszip@^3.1.5, jszip@^3.5.0:
+jszip@^3.1.5:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.5.0.tgz#b4fd1f368245346658e781fec9675802489e15f6"
   integrity sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    set-immediate-shim "~1.0.1"
+
+jszip@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.6.0.tgz#839b72812e3f97819cc13ac4134ffced95dd6af9"
+  integrity sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==
   dependencies:
     lie "~3.3.0"
     pako "~1.0.2"


### PR DESCRIPTION
Adds assertions to read the contents of the KMP file in the Cypress test.

Right now, the assertions are very basic — does the `.kmp` file contain the metadata file `kmp.json` and does it contain the JavaScript file (the compiled model).

Fixes #253 