### PR TITLE
Add developement-only error logging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,6 +6,3 @@
 
 API_KEY= YOUR_KEY_HERE
 CLIENT_ID= YOUR_CLIENT_HERE
-
-# Used to enable logging for developers
-DEVELOPMENT= true

--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,6 @@
 
 API_KEY= YOUR_KEY_HERE
 CLIENT_ID= YOUR_CLIENT_HERE
+
+# Used to enable logging for developers
+DEVELOPMENT= true

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,6 +34,7 @@ export const appConfiguration = {
     replace({
       CLIENT_ID: JSON.stringify(process.env.CLIENT_ID),
       API_KEY: JSON.stringify(process.env.API_KEY),
+      DEVELOPMENT: process.env?.DEVELOPMENT === 'true'
     }),
 
     svelte({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -34,7 +34,7 @@ export const appConfiguration = {
     replace({
       CLIENT_ID: JSON.stringify(process.env.CLIENT_ID),
       API_KEY: JSON.stringify(process.env.API_KEY),
-      DEVELOPMENT: process.env?.DEVELOPMENT === 'true'
+      DEVELOPMENT: watchMode === true
     }),
 
     svelte({

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -1,26 +1,26 @@
 declare const DEVELOPMENT: boolean;
 
-let hasWarnedDev: boolean = false;
+let hasWarnedDev = false;
 
 /**
  * Log an error in development mode.
  * Will warn if the .env file doesn't have DEVELOPEMENT equal to 'true'.
- * 
+ *
  * Should be used to warn that something went wrong.
- * 
+ *
  * @param e the error object to include. A message can be included in the object.
  */
-function logError(e: Error): void{
+function logError(e: Error): void {
   if (DEVELOPMENT) {
     console.error(e);
   } else {
-    if(!hasWarnedDev){
+    if (!hasWarnedDev) {
       // Message warns the dev that logging is disabled
-      console.warn('Developer Logging Not Enabled')
+      console.warn("Developer Logging Not Enabled");
       hasWarnedDev = true;
     }
     // Do nothing
   }
 }
 
-export {logError};
+export { logError };

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -1,6 +1,6 @@
 declare const DEVELOPMENT: boolean;
 
-let hasWarnedDev = false;
+let hasNotifiedDev = false;
 
 /**
  * Log an error in development mode.
@@ -12,14 +12,12 @@ let hasWarnedDev = false;
  */
 function logError(e: Error): void {
   if (DEVELOPMENT) {
-    console.error(e);
-  } else {
-    if (!hasWarnedDev) {
-      // Message warns the dev that logging is disabled
-      console.warn("Developer Logging Not Enabled");
-      hasWarnedDev = true;
+    if (!hasNotifiedDev) {
+      // Message to notify dev that logging is enabled
+      console.warn("Developer Logging Is Enabled");
+      hasNotifiedDev = true;
     }
-    // Do nothing
+    console.error(e);
   }
 }
 

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -1,0 +1,26 @@
+declare const DEVELOPMENT: boolean;
+
+let hasWarnedDev: boolean = false;
+
+/**
+ * Log an error in development mode.
+ * Will warn if the .env file doesn't have DEVELOPEMENT equal to 'true'.
+ * 
+ * Should be used to warn that something went wrong.
+ * 
+ * @param e the error object to include. A message can be included in the object.
+ */
+function logError(e: Error): void{
+  if (DEVELOPMENT) {
+    console.error(e);
+  } else {
+    if(!hasWarnedDev){
+      // Message warns the dev that logging is disabled
+      console.warn('Developer Logging Not Enabled')
+      hasWarnedDev = true;
+    }
+    // Do nothing
+  }
+}
+
+export {logError};


### PR DESCRIPTION
Add a new function that allows for error messages to be displayed if the app is in developer mode.
This allows developers to log errors if things go awry within the codebase, hopefully leading to faster debugging.

Changes
- Add new `DEVELOPER` parameter in `.env.template` to enable error logging
- Edit rollup config to work with the new `.env` parameter
- Add function to allow for error logging

Resolves #243
