### PR TITLE
Make Languages.svelte download button functional

### DIFF
--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -60,7 +60,10 @@ describe("Upload from the the landing page and Download KMP", function () {
   it("should download kmp file from languages download button", function () {
     cy.visit("/languages");
 
-    const downloadedFilePath = path.join(downloadFolder, "Predictive-Text-Studio-Dictionary.kmp");
+    const downloadedFilePath = path.join(
+      downloadFolder,
+      "Predictive-Text-Studio-Dictionary.kmp"
+    );
 
     cy.readFile(downloadedFilePath).should("not.exist");
 

--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -60,7 +60,7 @@ describe("Upload from the the landing page and Download KMP", function () {
   it("should download kmp file from languages download button", function () {
     cy.visit("/languages");
 
-    const downloadedFilePath = path.join(downloadFolder, "Example.kmp");
+    const downloadedFilePath = path.join(downloadFolder, "Predictive-Text-Studio-Dictionary.kmp");
 
     cy.readFile(downloadedFilePath).should("not.exist");
 

--- a/cypress/integration/upload.spec.ts
+++ b/cypress/integration/upload.spec.ts
@@ -2,7 +2,7 @@ import "cypress-file-upload";
 
 import path = require("path");
 
-describe("Upload from the the landing page", function () {
+describe("Upload from the the landing page and Download KMP", function () {
   let downloadFolder: string;
 
   before(() => {
@@ -55,5 +55,21 @@ describe("Upload from the the landing page", function () {
       expect(zip.file("kmp.json")).to.not.be.null;
       expect(zip.file(/[.]js$/)).to.have.lengthOf(1);
     });
+  });
+
+  it("should download kmp file from languages download button", function () {
+    cy.visit("/languages");
+
+    const downloadedFilePath = path.join(downloadFolder, "Example.kmp");
+
+    cy.readFile(downloadedFilePath).should("not.exist");
+
+    cy.data("languages-download-btn").scrollIntoView().should("be.visible");
+
+    cy.data("languages-download-btn")
+      .should("not.have.class", "button--disabled")
+      .click();
+
+    cy.readFile(downloadedFilePath).should("exist");
   });
 });

--- a/src/app/components/DownloadKMP.svelte
+++ b/src/app/components/DownloadKMP.svelte
@@ -23,7 +23,7 @@
   class:download-component--disabled={downloadURL == ''}>
   <a
     href={downloadURL ? downloadURL : '#'}
-    download="Predictive-Text-Studio-Dictionary.kmp"
+    download="Example.kmp"
     class="download-component__link"
     class:download-component__link--disabled={downloadURL == ''}
     data-cy="download-kmp"

--- a/src/app/components/DownloadKMP.svelte
+++ b/src/app/components/DownloadKMP.svelte
@@ -23,7 +23,7 @@
   class:download-component--disabled={downloadURL == ''}>
   <a
     href={downloadURL ? downloadURL : '#'}
-    download="Example.kmp"
+    download="Predictive-Text-Studio-Dictionary.kmp"
     class="download-component__link"
     class:download-component__link--disabled={downloadURL == ''}
     data-cy="download-kmp"

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -58,7 +58,7 @@
   const handleDownload = async () => {
     let { dictionaryName } = await worker.fetchAllCurrentProjectMetadata();
 
-    if (!dictionaryName) dictionaryName = "Example";
+    if (!dictionaryName) dictionaryName = "Predictive-Text-Studio-Dictionary";
 
     const anchor = document.createElement("a");
     anchor.href = $currentDownloadURL;
@@ -67,6 +67,8 @@
 
     // Auto click on a element, trigger the file download
     anchor.click();
+
+    anchor.remove();
   };
 </script>
 

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -5,7 +5,7 @@
   import LanguageSources from "../components/LanguageSources.svelte";
   import Button from "../components/Button.svelte";
   import worker from "../spawn-worker";
-  import { compileSuccess } from "../stores";
+  import { compileSuccess, currentDownloadURL } from "../stores";
   import { setupAutomaticCompilationAndDownloadURL } from "../logic/automatic-compilation";
 
   export let selectedButton: string = "information";
@@ -52,12 +52,22 @@
   };
 
   /**
-   * Handles the click when the download language button is pressed. Should download a .kmp file.
-   * TODO: Replace stub
-   *
+   * Handles the click when the download language button is pressed. downloads a .kmp file.
    * @return {void}
    */
-  const handleDownload = (): void => {};
+  const handleDownload = async () => {
+    let { dictionaryName } = await worker.fetchAllCurrentProjectMetadata();
+
+    if (!dictionaryName) dictionaryName = "Example";
+
+    const anchor = document.createElement("a");
+    anchor.href = $currentDownloadURL;
+    anchor.target = "_blank";
+    anchor.download = `${dictionaryName}.kmp`;
+
+    // Auto click on a element, trigger the file download
+    anchor.click();
+  };
 </script>
 
 <style>


### PR DESCRIPTION
Makes the download button on the language page download the up-to-date customized KMP file with name corresponding to the dictionary name in the database. 

Resolves #266 
