### PR TITLE
Feat/edit and delete dict sources

### DIFF
--- a/cypress/integration/manualEntry.spec.ts
+++ b/cypress/integration/manualEntry.spec.ts
@@ -1,8 +1,52 @@
 describe("Adding sources by direct entry", function () {
-  it("should find a button to press to add source by user entry manually", function () {
+  beforeEach(() => {
     cy.visit("/languages");
     cy.data("languages-sources-btn").contains("Sources").click();
+  });
 
+  it("should create and delete a manual entry source", function () {
+    // create the manual entry
+    cy.data("language-sources-add-sources")
+      .contains("Add Source")
+      .click()
+      .scrollIntoView();
+
+    cy.data("add-sources-splitbtn-direct-entry")
+      .contains("Direct entry")
+      .click()
+      .scrollIntoView();
+    cy.data("manual-entry-input-tablename").type("Common Greetings");
+    cy.data("manual-entry-input-word").type("Hello");
+    cy.data("manual-entry-input-count").clear().type("112");
+    // delete the entry
+    cy.data("language-source-delete").click();
+  });
+
+  it("should create and later edit a manual entry source", function () {
+    // create the manual entry
+    cy.data("language-sources-add-sources")
+      .contains("Add Source")
+      .click()
+      .scrollIntoView();
+
+    cy.data("add-sources-splitbtn-direct-entry")
+      .contains("Direct entry")
+      .click()
+      .scrollIntoView();
+    cy.data("manual-entry-input-tablename").type("Common Greetings");
+    cy.data("manual-entry-input-word").type("Hello");
+    cy.data("manual-entry-input-count").clear().type("112");
+
+    // edit the entry
+    cy.data("languages-sources-btn").contains("Sources").click();
+    cy.data("language-source-edit").click();
+
+    cy.data("manual-entry-input-tablename").first().should("be.disabled");
+    cy.data("manual-entry-input-word").first().type("World");
+    cy.data("manual-entry-input-count").first().clear().type("113");
+  });
+
+  it("should find a button to press to add source by user entry manually", function () {
     // Add source component should show after clicking the details element
     cy.data("language-sources-add-sources")
       .contains("Add Source")
@@ -15,7 +59,7 @@ describe("Adding sources by direct entry", function () {
       .scrollIntoView();
     cy.data("manual-entry-input-tablename").type("Common Greetings");
     cy.data("manual-entry-input-word").type("Hello");
-    cy.data("manual-entry-input-count").type("112");
+    cy.data("manual-entry-input-count").clear().type("112");
 
     cy.data("manual-entry-delete").contains("Delete").click();
     //TODO: Current row should be deleted

--- a/cypress/integration/manualEntry.spec.ts
+++ b/cypress/integration/manualEntry.spec.ts
@@ -19,7 +19,7 @@ describe("Adding sources by direct entry", function () {
     cy.data("manual-entry-input-word").type("Hello");
     cy.data("manual-entry-input-count").clear().type("112");
     // delete the entry
-    cy.data("language-source-delete").click();
+    cy.data("language-source-delete").first().click();
   });
 
   it("should create and later edit a manual entry source", function () {
@@ -39,7 +39,7 @@ describe("Adding sources by direct entry", function () {
 
     // edit the entry
     cy.data("languages-sources-btn").contains("Sources").click();
-    cy.data("language-source-edit").click();
+    cy.data("language-source-edit").first().click();
 
     cy.data("manual-entry-input-tablename").first().should("be.disabled");
     cy.data("manual-entry-input-word").first().type("World");

--- a/src/app/components/AddSource.svelte
+++ b/src/app/components/AddSource.svelte
@@ -2,7 +2,7 @@
   import SplitButton from "./SplitButton.svelte";
   import ManualEntry from "./ManualEntry.svelte";
   import Upload from "./Upload.svelte";
-import type { WordList, WordListSource } from "@common/types";
+  import type { WordList, WordListSource } from "@common/types";
 
   /**
    * Re-calculate word count
@@ -42,12 +42,12 @@ import type { WordList, WordListSource } from "@common/types";
   ];
   // Manual Entry
   let manualEntry: boolean = false;
-  let initialWordlist: WordList = [["",0]];
+  let initialWordlist: WordList = [["", 0]];
   let tableData: WordListSource = {
     name: "",
     wordlist: initialWordlist,
-    size:0,
-    type: "direct-entry"
+    size: 0,
+    type: "direct-entry",
   };
 </script>
 
@@ -66,7 +66,7 @@ import type { WordList, WordListSource } from "@common/types";
 </div>
 
 {#if manualEntry}
-  <ManualEntry getLanguageSources={getLanguageSources} tableData={tableData} />
+  <ManualEntry {getLanguageSources} {tableData} />
 {:else}
-  <Upload getLanguageSources={getLanguageSources} />
+  <Upload {getLanguageSources} />
 {/if}

--- a/src/app/components/AddSource.svelte
+++ b/src/app/components/AddSource.svelte
@@ -2,11 +2,12 @@
   import SplitButton from "./SplitButton.svelte";
   import ManualEntry from "./ManualEntry.svelte";
   import Upload from "./Upload.svelte";
+import type { WordList, WordListSource } from "@common/types";
 
   /**
    * Re-calculate word count
    */
-  export let getLanguageSources = async () => {};
+  export let getLanguageSources: Function;
 
   // Split Button
   const uploadSourcesFromFile = () => {
@@ -41,13 +42,12 @@
   ];
   // Manual Entry
   let manualEntry: boolean = false;
-  let tableData = {
+  let initialWordlist: WordList = [["",0]];
+  let tableData: WordListSource = {
     name: "",
-    data: [
-      {
-        word: "",
-      },
-    ],
+    wordlist: initialWordlist,
+    size:0,
+    type: "direct-entry"
   };
 </script>
 
@@ -66,7 +66,7 @@
 </div>
 
 {#if manualEntry}
-  <ManualEntry {getLanguageSources} {tableData} />
+  <ManualEntry getLanguageSources={getLanguageSources} tableData={tableData} />
 {:else}
-  <Upload {getLanguageSources} />
+  <Upload getLanguageSources={getLanguageSources} />
 {/if}

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import AddSource from "./AddSource.svelte";
   import type { WordListSource } from "@common/types";
+  import { removeDictionaryFromProject } from "../logic/delete";
   export let sources: WordListSource[];
 
   /**
@@ -13,11 +14,13 @@
 
   /**
    * Handles the click when the delete button is pressed.
-   * TODO: Replace stub
    *
    * @return {void}
    */
-  const handleDelete = (): void => {};
+  async function handleDelete(sourceToDelete:WordListSource): Promise<void>{
+    await removeDictionaryFromProject(sourceToDelete.name);
+    sources = sources.filter(source => source.name != sourceToDelete.name);
+  };
 
   const englishNameOf = {
     "direct-entry": "Direct entry",
@@ -107,7 +110,7 @@
             <button class="actions__action btn--inline" on:click={handleEdit}>
               <img src="/icons/edit.svg" alt="edit" />
             </button>
-            <button class="actions__action btn--inline" on:click={handleDelete}>
+            <button class="actions__action btn--inline" on:click={()=>handleDelete(source)}>
               <img src="/icons/delete.svg" alt="delete" />
             </button>
           </td>

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -136,7 +136,7 @@
       <ManualEntry
         tableData={sourceBeingEdited}
         {getLanguageSources}
-        isEditingSource={true} />
+        isEditingSource={true}/>
     {/if}
   </div>
   <details data-cy="language-sources-add-sources">

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -120,12 +120,14 @@
           <td class="table__row--actions actions">
             <button
               class="actions__action btn--inline"
-              on:click={() => handleEdit(source)}>
+              on:click={() => handleEdit(source)}
+              data-cy="language-source-edit">
               <img src="/icons/edit.svg" alt="edit" />
             </button>
             <button
               class="actions__action btn--inline"
-              on:click={() => handleDelete(source)}>
+              on:click={() => handleDelete(source)}
+              data-cy="language-source-delete">
               <img src="/icons/delete.svg" alt="delete" />
             </button>
           </td>

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -17,10 +17,10 @@
    *
    * @return {void}
    */
-  async function handleDelete(sourceToDelete:WordListSource): Promise<void>{
+  async function handleDelete(sourceToDelete: WordListSource): Promise<void> {
     await removeDictionaryFromProject(sourceToDelete.name);
-    sources = sources.filter(source => source.name != sourceToDelete.name);
-  };
+    sources = sources.filter((source) => source.name != sourceToDelete.name);
+  }
 
   const englishNameOf = {
     "direct-entry": "Direct entry",
@@ -110,7 +110,9 @@
             <button class="actions__action btn--inline" on:click={handleEdit}>
               <img src="/icons/edit.svg" alt="edit" />
             </button>
-            <button class="actions__action btn--inline" on:click={()=>handleDelete(source)}>
+            <button
+              class="actions__action btn--inline"
+              on:click={() => handleDelete(source)}>
               <img src="/icons/delete.svg" alt="delete" />
             </button>
           </td>

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -136,7 +136,7 @@
       <ManualEntry
         tableData={sourceBeingEdited}
         {getLanguageSources}
-        isEditingSource={true}/>
+        isEditingSource={true} />
     {/if}
   </div>
   <details data-cy="language-sources-add-sources">

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -2,7 +2,7 @@
   import AddSource from "./AddSource.svelte";
   import type { WordListSource } from "@common/types";
   import { removeDictionaryFromProject } from "../logic/delete";
-import ManualEntry from "./ManualEntry.svelte";
+  import ManualEntry from "./ManualEntry.svelte";
   export let sources: WordListSource[];
 
   /**
@@ -10,7 +10,7 @@ import ManualEntry from "./ManualEntry.svelte";
    */
   export let getLanguageSources: Function;
 
-  let sourceBeingEdited: WordListSource|null = null;
+  let sourceBeingEdited: WordListSource | null = null;
 
   /**
    * Handles the click when the edit button is pressed.
@@ -18,7 +18,7 @@ import ManualEntry from "./ManualEntry.svelte";
    *
    * @return {void}
    */
-  function handleEdit(sourceToEdit: WordListSource): void{
+  function handleEdit(sourceToEdit: WordListSource): void {
     sourceBeingEdited = sourceToEdit;
   }
 
@@ -118,7 +118,9 @@ import ManualEntry from "./ManualEntry.svelte";
           <td>{source.size}</td>
           <td>{englishNameOf[source.type]}</td>
           <td class="table__row--actions actions">
-            <button class="actions__action btn--inline" on:click={() => handleEdit(source)}>
+            <button
+              class="actions__action btn--inline"
+              on:click={() => handleEdit(source)}>
               <img src="/icons/edit.svg" alt="edit" />
             </button>
             <button
@@ -131,7 +133,10 @@ import ManualEntry from "./ManualEntry.svelte";
       {/each}
     </table>
     {#if sourceBeingEdited !== null}
-      <ManualEntry tableData={sourceBeingEdited} getLanguageSources={getLanguageSources} isEditingSource={true}/>
+      <ManualEntry
+        tableData={sourceBeingEdited}
+        {getLanguageSources}
+        isEditingSource={true} />
     {/if}
   </div>
   <details data-cy="language-sources-add-sources">

--- a/src/app/components/LanguageSources.svelte
+++ b/src/app/components/LanguageSources.svelte
@@ -2,12 +2,15 @@
   import AddSource from "./AddSource.svelte";
   import type { WordListSource } from "@common/types";
   import { removeDictionaryFromProject } from "../logic/delete";
+import ManualEntry from "./ManualEntry.svelte";
   export let sources: WordListSource[];
 
   /**
    * Re-calculate word count
    */
-  export let getLanguageSources = async () => {};
+  export let getLanguageSources: Function;
+
+  let sourceBeingEdited: WordListSource|null = null;
 
   /**
    * Handles the click when the edit button is pressed.
@@ -15,7 +18,9 @@
    *
    * @return {void}
    */
-  const handleEdit = (): void => {};
+  function handleEdit(sourceToEdit: WordListSource): void{
+    sourceBeingEdited = sourceToEdit;
+  }
 
   /**
    * Handles the click when the delete button is pressed.
@@ -81,6 +86,7 @@
     padding: 0;
     border: 0;
     background-color: transparent;
+    cursor: pointer;
   }
 
   img {
@@ -112,7 +118,7 @@
           <td>{source.size}</td>
           <td>{englishNameOf[source.type]}</td>
           <td class="table__row--actions actions">
-            <button class="actions__action btn--inline" on:click={handleEdit}>
+            <button class="actions__action btn--inline" on:click={() => handleEdit(source)}>
               <img src="/icons/edit.svg" alt="edit" />
             </button>
             <button
@@ -124,6 +130,9 @@
         </tr>
       {/each}
     </table>
+    {#if sourceBeingEdited !== null}
+      <ManualEntry tableData={sourceBeingEdited} getLanguageSources={getLanguageSources} isEditingSource={true}/>
+    {/if}
   </div>
   <details data-cy="language-sources-add-sources">
     <summary>Add Source</summary>

--- a/src/app/components/ManualEntry.svelte
+++ b/src/app/components/ManualEntry.svelte
@@ -55,12 +55,9 @@
 
   const saveTableData = async () => {
     if (validDictionary) {
-      if (isEditingSource){
-        console.log(originalTableName)
-        await worker.updateDictionaryInProject(
-          originalTableName,
-          tableData
-        );
+      if (isEditingSource) {
+        console.log(originalTableName);
+        await worker.updateDictionaryInProject(originalTableName, tableData);
         originalTableName = tableData.name;
       } else {
         await worker.addManualEntryDictionaryToProject(

--- a/src/app/components/ManualEntry.svelte
+++ b/src/app/components/ManualEntry.svelte
@@ -1,25 +1,27 @@
 <script lang="ts">
   import Button from "./Button.svelte";
   import worker from "../spawn-worker";
-  import type { WordAndCount, WordList } from "@common/types";
+  import type { WordAndCount, WordList, WordListSource } from "@common/types";
   import { WordAndCountInd } from "@common/types";
 
-  export let tableData: {
-    name: string;
-    wordlist: WordList;
-  };
+  export let tableData: WordListSource;
+
+  let originalTableName = tableData.name;
 
   /**
    * Re-calculate word count
    */
-  export let getLanguageSources = async () => {};
+  export let getLanguageSources: Function;
+
+  /**
+   * Determines if this component is editing a source.
+   */
+  export let isEditingSource: boolean = false;
+
   $: rowDataFromManualEntry = tableData.wordlist;
   $: validDictionary = validateTableData(tableData.name, tableData.wordlist);
   $: if (validDictionary) {
-    worker.addManualEntryDictionaryToProject(
-      tableData.name,
-      tableData.wordlist
-    );
+    saveTableData();
   }
 
   const validInput = (input: string): boolean => {
@@ -53,10 +55,19 @@
 
   const saveTableData = async () => {
     if (validDictionary) {
-      await worker.addManualEntryDictionaryToProject(
-        tableData.name,
-        tableData.wordlist
-      );
+      if (isEditingSource){
+        console.log(originalTableName)
+        await worker.updateDictionaryInProject(
+          originalTableName,
+          tableData
+        );
+        originalTableName = tableData.name;
+      } else {
+        await worker.addManualEntryDictionaryToProject(
+          tableData.name,
+          tableData.wordlist
+        );
+      }
       getLanguageSources();
     }
   };

--- a/src/app/components/ManualEntry.svelte
+++ b/src/app/components/ManualEntry.svelte
@@ -12,7 +12,10 @@
   $: rowDataFromManualEntry = tableData.wordlist;
   $: validDictionary = validateTableData(tableData.name, tableData.wordlist);
   $: if (validDictionary) {
-    worker.addManualEntryDictionaryToProject(tableData.name, tableData.wordlist);
+    worker.addManualEntryDictionaryToProject(
+      tableData.name,
+      tableData.wordlist
+    );
   }
 
   const validInput = (input: string): boolean => {
@@ -24,7 +27,7 @@
     );
   };
 
-  const validateTableData = (name:string, wordlist:WordList): boolean => {
+  const validateTableData = (name: string, wordlist: WordList): boolean => {
     const validTitle = validInput(name);
 
     const validRows = wordlist.every((wordAndCount: WordAndCount) => {
@@ -39,14 +42,17 @@
   };
 
   const addNewRow = (): void => {
-    const newEntry: WordAndCount = ["",0]
+    const newEntry: WordAndCount = ["", 0];
     rowDataFromManualEntry.push(newEntry);
     rowDataFromManualEntry = rowDataFromManualEntry;
   };
 
   const saveTableData = async () => {
     if (validDictionary) {
-      await worker.addManualEntryDictionaryToProject(tableData.name, tableData.wordlist);
+      await worker.addManualEntryDictionaryToProject(
+        tableData.name,
+        tableData.wordlist
+      );
     }
   };
 </script>

--- a/src/app/components/ManualEntry.svelte
+++ b/src/app/components/ManualEntry.svelte
@@ -6,21 +6,20 @@
 
   export let tableData: WordListSource;
 
-  let originalTableName = tableData.name;
-
   /**
    * Re-calculate word count
    */
   export let getLanguageSources: Function;
 
   /**
-   * Determines if this component is editing a source.
+   * Disables being able to edit the title
+   * We no longer need this conditional if we work with IndexedDB IDs
    */
   export let isEditingSource: boolean = false;
 
   $: rowDataFromManualEntry = tableData.wordlist;
   $: validDictionary = validateTableData(tableData.name, tableData.wordlist);
-  $: if (validDictionary) {
+  $: if (validateTableData(tableData.name, tableData.wordlist)) {
     saveTableData();
   }
 
@@ -55,16 +54,10 @@
 
   const saveTableData = async () => {
     if (validDictionary) {
-      if (isEditingSource) {
-        console.log(originalTableName);
-        await worker.updateDictionaryInProject(originalTableName, tableData);
-        originalTableName = tableData.name;
-      } else {
-        await worker.addManualEntryDictionaryToProject(
-          tableData.name,
-          tableData.wordlist
-        );
-      }
+      await worker.addManualEntryDictionaryToProject(
+        tableData.name,
+        tableData.wordlist
+      );
       getLanguageSources();
     }
   };
@@ -168,6 +161,7 @@
     <input
       type="text"
       bind:value={tableData.name}
+      disabled={isEditingSource}
       required
       data-cy="manual-entry-input-tablename" />
   </div>

--- a/src/app/components/Upload.svelte
+++ b/src/app/components/Upload.svelte
@@ -21,7 +21,7 @@
   /**
    * Re-calculate word count
    */
-  export let getLanguageSources = async () => {};
+  export let getLanguageSources: Function = () => {};
 
   async function uploadFilesFromDragAndDrop(event: DragEvent) {
     dragEnterCounter = 0;

--- a/src/app/logic/delete.ts
+++ b/src/app/logic/delete.ts
@@ -1,0 +1,6 @@
+import worker from "../spawn-worker";
+export async function removeDictionaryFromProject(
+  sourceName:string
+): Promise<void> {
+  await worker.removeDictionaryFromProject(sourceName);
+}

--- a/src/app/logic/delete.ts
+++ b/src/app/logic/delete.ts
@@ -1,6 +1,6 @@
 import worker from "../spawn-worker";
 export async function removeDictionaryFromProject(
-  sourceName:string
+  sourceName: string
 ): Promise<void> {
   await worker.removeDictionaryFromProject(sourceName);
 }

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -172,7 +172,7 @@
         {#if selectedButton === 'information'}
           <LanguageInfo />
         {:else if selectedButton === 'sources'}
-          <LanguageSources sources={languageInformation.sources} />
+          <LanguageSources bind:sources={languageInformation.sources} />
         {/if}
       </div>
     </div>

--- a/src/common/predictive-text-studio-worker.ts
+++ b/src/common/predictive-text-studio-worker.ts
@@ -30,11 +30,14 @@ export interface PredictiveTextStudioWorker {
 
   /**
    * Updates a dictionary within the IndexedDB
-   * @param originalDictionaryName 
-   * @param newDictionary 
+   * @param originalDictionaryName
+   * @param newDictionary
    * @return {number} the count of words in the source
    */
-  updateDictionaryInProject(originalDictionaryName: string, newDictionary: WordListSource): Promise<number>;
+  updateDictionaryInProject(
+    originalDictionaryName: string,
+    newDictionary: WordListSource
+  ): Promise<number>;
 
   /**
    * Remove a dictionary within the IndexedDB

--- a/src/common/predictive-text-studio-worker.ts
+++ b/src/common/predictive-text-studio-worker.ts
@@ -29,6 +29,14 @@ export interface PredictiveTextStudioWorker {
   addDictionarySourceToProject(name: string, contents: File): Promise<number>;
 
   /**
+   * Updates a dictionary within the IndexedDB
+   * @param originalDictionaryName 
+   * @param newDictionary 
+   * @return {number} the count of words in the source
+   */
+  updateDictionaryInProject(originalDictionaryName: string, newDictionary: WordListSource): Promise<number>;
+
+  /**
    * Remove a dictionary within the IndexedDB
    * @param name the name of the wordlist to remove
    */

--- a/src/common/predictive-text-studio-worker.ts
+++ b/src/common/predictive-text-studio-worker.ts
@@ -39,7 +39,10 @@ export interface PredictiveTextStudioWorker {
    * @param name the name of the dictionary souce
    * @param wordlist Manual entry data
    */
-  addManualEntryDictionaryToProject(name:string, wordlist: WordList): Promise<number>;
+  addManualEntryDictionaryToProject(
+    name: string,
+    wordlist: WordList
+  ): Promise<number>;
 
   ///////////////////////////// Event handlers /////////////////////////////
 

--- a/src/common/predictive-text-studio-worker.ts
+++ b/src/common/predictive-text-studio-worker.ts
@@ -29,17 +29,6 @@ export interface PredictiveTextStudioWorker {
   addDictionarySourceToProject(name: string, contents: File): Promise<number>;
 
   /**
-   * Updates a dictionary within the IndexedDB
-   * @param originalDictionaryName
-   * @param newDictionary
-   * @return {number} the count of words in the source
-   */
-  updateDictionaryInProject(
-    originalDictionaryName: string,
-    newDictionary: WordListSource
-  ): Promise<number>;
-
-  /**
    * Remove a dictionary within the IndexedDB
    * @param name the name of the wordlist to remove
    */

--- a/src/common/predictive-text-studio-worker.ts
+++ b/src/common/predictive-text-studio-worker.ts
@@ -30,6 +30,12 @@ export interface PredictiveTextStudioWorker {
   addDictionarySourceToProject(name: string, contents: File): Promise<number>;
 
   /**
+   * Remove a dictionary within the IndexedDB
+   * @param name the name of the wordlist to remove
+   */
+  removeDictionaryFromProject(name: string): Promise<number>;
+
+  /**
    * Store the manual entry data into the database
    * @param tableData Manual entry data
    */

--- a/src/common/predictive-text-studio-worker.ts
+++ b/src/common/predictive-text-studio-worker.ts
@@ -4,7 +4,6 @@
 
 import type { RelevantKmpOptions } from "@common/kmp-json-file";
 import type {
-  DictionaryEntry,
   KeyboardDataWithTime,
   ProjectMetadata,
   WordList,
@@ -37,12 +36,10 @@ export interface PredictiveTextStudioWorker {
 
   /**
    * Store the manual entry data into the database
-   * @param tableData Manual entry data
+   * @param name the name of the dictionary souce
+   * @param wordlist Manual entry data
    */
-  addManualEntryDictionaryToProject(tableData: {
-    name: string;
-    data: DictionaryEntry[];
-  }): Promise<number>;
+  addManualEntryDictionaryToProject(name:string, wordlist: WordList): Promise<number>;
 
   ///////////////////////////// Event handlers /////////////////////////////
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -9,7 +9,7 @@ export type WordAndCount = [string, number];
  */
 export enum WordAndCountInd {
   WORD = 0,
-  COUNT = 1
+  COUNT = 1,
 }
 
 /**

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -55,14 +55,6 @@ export interface WordListSource {
   type: DictionarySourceType;
 }
 
-// /**
-//  * A manually entered collection of words and their counts.
-//  */
-// export interface DictionaryEntry {
-//   word: string;
-//   count?: number;
-// }
-
 /**
  * Stores information about a known keyboard layout.
  */

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -5,6 +5,14 @@
 export type WordAndCount = [string, number];
 
 /**
+ * A set of constants to get the Word and Count
+ */
+export enum WordAndCountInd {
+  WORD = 0,
+  COUNT = 1
+}
+
+/**
  * A collection of words and their counts.
  *
  * This list can be used to create a
@@ -47,13 +55,13 @@ export interface WordListSource {
   type: DictionarySourceType;
 }
 
-/**
- * A manually entered collection of words and their counts.
- */
-export interface DictionaryEntry {
-  word: string;
-  count?: number;
-}
+// /**
+//  * A manually entered collection of words and their counts.
+//  */
+// export interface DictionaryEntry {
+//   word: string;
+//   count?: number;
+// }
 
 /**
  * Stores information about a known keyboard layout.

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -134,9 +134,10 @@ export class PredictiveTextStudioWorkerImpl
     return 1;
   }
 
-  async addManualEntryDictionaryToProject (
-    name:string, wordlist: WordList
-  ) : Promise<number> {
+  async addManualEntryDictionaryToProject(
+    name: string,
+    wordlist: WordList
+  ): Promise<number> {
     await this.storage.saveFile({
       name: name,
       wordlist,

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -129,7 +129,10 @@ export class PredictiveTextStudioWorkerImpl
     return wordlist.length;
   }
 
-  async updateDictionaryInProject(originalDictionaryName: string, newDictionary: WordListSource): Promise<number>{
+  async updateDictionaryInProject(
+    originalDictionaryName: string,
+    newDictionary: WordListSource
+  ): Promise<number> {
     await this.storage.updateFile(originalDictionaryName, newDictionary);
     return newDictionary.size;
   }

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -1,7 +1,6 @@
 import type { PredictiveTextStudioWorker } from "@common/predictive-text-studio-worker";
 import type { RelevantKmpOptions } from "@common/kmp-json-file";
 import type {
-  DictionaryEntry,
   DictionarySourceType,
   ProjectMetadata,
   WordList,
@@ -12,7 +11,7 @@ import Storage from "./storage";
 import { KeyboardData, KeyboardDataWithTime } from "./storage-models";
 import { KeymanAPI } from "./keyman-api-service";
 import { linkStorageToKmp } from "./link-storage-to-kmp";
-import { readExcel, readManualEntryData, readTSV } from "./read-wordlist";
+import { readExcel, readTSV } from "./read-wordlist";
 
 /**
  * expiryThreshold is used to decide if keyboard data is too old
@@ -135,14 +134,11 @@ export class PredictiveTextStudioWorkerImpl
     return 1;
   }
 
-  async addManualEntryDictionaryToProject(tableData: {
-    name: string;
-    data: DictionaryEntry[];
-  }): Promise<number> {
-    const dictionaryName = tableData.name;
-    const wordlist = readManualEntryData(tableData.data);
+  async addManualEntryDictionaryToProject (
+    name:string, wordlist: WordList
+  ) : Promise<number> {
     await this.storage.saveFile({
-      name: dictionaryName,
+      name: name,
       wordlist,
       size: wordlist.length,
       type: "direct-entry",

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -130,6 +130,13 @@ export class PredictiveTextStudioWorkerImpl
     return wordlist.length;
   }
 
+  async removeDictionaryFromProject(
+    name:string
+  ): Promise<number> {
+    await this.storage.deleteFile(name);
+    return 1;
+  }
+
   async addManualEntryDictionaryToProject(tableData: {
     name: string;
     data: DictionaryEntry[];

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -130,9 +130,7 @@ export class PredictiveTextStudioWorkerImpl
     return wordlist.length;
   }
 
-  async removeDictionaryFromProject(
-    name:string
-  ): Promise<number> {
+  async removeDictionaryFromProject(name: string): Promise<number> {
     await this.storage.deleteFile(name);
     return 1;
   }

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -129,6 +129,11 @@ export class PredictiveTextStudioWorkerImpl
     return wordlist.length;
   }
 
+  async updateDictionaryInProject(originalDictionaryName: string, newDictionary: WordListSource): Promise<number>{
+    await this.storage.updateFile(originalDictionaryName, newDictionary);
+    return newDictionary.size;
+  }
+
   async removeDictionaryFromProject(name: string): Promise<number> {
     await this.storage.deleteFile(name);
     return 1;

--- a/src/worker/predictive-text-studio-worker-impl.ts
+++ b/src/worker/predictive-text-studio-worker-impl.ts
@@ -129,14 +129,6 @@ export class PredictiveTextStudioWorkerImpl
     return wordlist.length;
   }
 
-  async updateDictionaryInProject(
-    originalDictionaryName: string,
-    newDictionary: WordListSource
-  ): Promise<number> {
-    await this.storage.updateFile(originalDictionaryName, newDictionary);
-    return newDictionary.size;
-  }
-
   async removeDictionaryFromProject(name: string): Promise<number> {
     await this.storage.deleteFile(name);
     return 1;

--- a/src/worker/read-wordlist.ts
+++ b/src/worker/read-wordlist.ts
@@ -1,6 +1,5 @@
 import * as Excel from "exceljs";
 import { WordList } from "@common/types";
-import { DictionaryEntry } from "@common/types";
 
 const WORD = 1;
 const COUNT = 2;
@@ -95,11 +94,11 @@ function asNonNegativeInteger(x: unknown): number {
   return n;
 }
 
-export function readManualEntryData(contents: DictionaryEntry[]): WordList {
-  const wordlist: WordList = contents.map((row) => {
-    const word = row.word;
-    const count = asNonNegativeInteger(row.count || 0);
-    return [word, count];
-  });
-  return wordlist;
-}
+// export function readManualEntryData(contents: DictionaryEntry[]): WordList {
+//   const wordlist: WordList = contents.map((row) => {
+//     const word = row.word;
+//     const count = asNonNegativeInteger(row.count || 0);
+//     return [word, count];
+//   });
+//   return wordlist;
+// }

--- a/src/worker/read-wordlist.ts
+++ b/src/worker/read-wordlist.ts
@@ -93,12 +93,3 @@ function asNonNegativeInteger(x: unknown): number {
 
   return n;
 }
-
-// export function readManualEntryData(contents: DictionaryEntry[]): WordList {
-//   const wordlist: WordList = contents.map((row) => {
-//     const word = row.word;
-//     const count = asNonNegativeInteger(row.count || 0);
-//     return [word, count];
-//   });
-//   return wordlist;
-// }

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -127,6 +127,15 @@ export default class Storage {
   }
 
   /**
+   * Deletes a wordlist source file from storage.
+   */
+  deleteFile(name: string): Promise<void> {
+    return this.db.transaction("readwrite", this.db.files, async () => {
+      await this.db.files.where("name").equals(name).delete();
+    });
+  }
+
+  /**
    * Retrieves every file in the database as a list of {name, contents}
    * objects.
    */

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -129,6 +129,19 @@ export default class Storage {
   }
 
   /**
+   * Updates a wordlist source file to storage.
+   * Removes the old entry and writes a new one to storage.
+   * @param name 
+   * @returns 
+   */
+   updateFile(oldFileName: string, newStoredWordList: StoredWordList): Promise<void> {
+    return this.db.transaction("readwrite", this.db.files, async () => {
+      await this.db.files.where("name").equals(oldFileName).delete();
+      await this.db.files.put(newStoredWordList);
+    });
+  }
+
+  /**
    * Deletes a wordlist source file from storage.
    */
   deleteFile(name: string): Promise<void> {
@@ -139,10 +152,10 @@ export default class Storage {
 
   /**
    * Retrieves every file in the database as a list of {name, contents}
-   * objects.
+   * objects. Sorts the files by name.
    */
   fetchAllFiles(): Promise<StoredWordList[]> {
-    return this.db.files.toArray();
+    return this.db.files.orderBy("name").toArray();
   }
 
   /**

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -131,10 +131,13 @@ export default class Storage {
   /**
    * Updates a wordlist source file to storage.
    * Removes the old entry and writes a new one to storage.
-   * @param name 
-   * @returns 
+   * @param name
+   * @returns
    */
-   updateFile(oldFileName: string, newStoredWordList: StoredWordList): Promise<void> {
+  updateFile(
+    oldFileName: string,
+    newStoredWordList: StoredWordList
+  ): Promise<void> {
     return this.db.transaction("readwrite", this.db.files, async () => {
       await this.db.files.where("name").equals(oldFileName).delete();
       await this.db.files.put(newStoredWordList);

--- a/src/worker/storage.ts
+++ b/src/worker/storage.ts
@@ -129,22 +129,6 @@ export default class Storage {
   }
 
   /**
-   * Updates a wordlist source file to storage.
-   * Removes the old entry and writes a new one to storage.
-   * @param name
-   * @returns
-   */
-  updateFile(
-    oldFileName: string,
-    newStoredWordList: StoredWordList
-  ): Promise<void> {
-    return this.db.transaction("readwrite", this.db.files, async () => {
-      await this.db.files.where("name").equals(oldFileName).delete();
-      await this.db.files.put(newStoredWordList);
-    });
-  }
-
-  /**
    * Deletes a wordlist source file from storage.
    */
   deleteFile(name: string): Promise<void> {

--- a/test/test-storage.ts
+++ b/test/test-storage.ts
@@ -50,6 +50,63 @@ test("storing a file", async (t) => {
   t.is(await db.files.count(), 1);
 });
 
+test("deleting a file", async (t) => {
+  const { db, storage } = t.context;
+
+  // Create a file
+  t.is(await db.files.count(), 0);
+
+  await storage.saveFile({
+    name: "ExampleWordlist.xlsx",
+    wordlist: exampleWordlist,
+    size: exampleWordlist.length,
+    type: "xlsx",
+  });
+
+  t.is(await db.files.count(), 1);
+
+  // Delete it
+  await storage.deleteFile("ExampleWordlist.xlsx");
+
+  // There should be no file remaining
+  t.is(await db.files.count(), 0);
+});
+
+test("editing a file", async (t) => {
+  const { db, storage } = t.context;
+
+  // Create a file
+  t.is(await db.files.count(), 0);
+
+  await storage.saveFile({
+    name: "ExampleWordlist.xlsx",
+    wordlist: exampleWordlist,
+    size: exampleWordlist.length,
+    type: "xlsx",
+  });
+
+  t.is(await db.files.count(), 1);
+
+  const newWordList = exampleWordlist.concat(["NEW_WORD", 22]);
+
+  // Edit it
+  await storage.saveFile({
+    name: "ExampleWordlist.xlsx",
+    wordlist: newWordList,
+    size: newWordList.length,
+    type: "xlsx",
+  });
+
+  // Check that the wordlist has been modified:
+  const files = await storage.fetchAllFiles();
+  t.is(files.length, 1);
+
+  const file = files[0];
+  t.is(file.name, "ExampleWordlist.xlsx");
+  t.deepEqual(file.wordlist, newWordList);
+  t.notDeepEqual(file.wordlist, exampleWordlist);
+});
+
 test("retrieving one file with .fetchAllFiles()", async (t) => {
   const { storage } = t.context;
 


### PR DESCRIPTION
This pull request allows for Dictionary sources to be updated and deleted.
The PR includes refactorings and tests

Added code:
- Allow for dictionary sources to be edited and deleted in `src/app/components/LanguageSources.svelte`
- Add new method to delete dictionary sources in `src/worker/storage.ts` and in `src/app/logic/delete.ts`

Changed code:
- Remove the `DictionaryEntry` type and all references to it. Converted all previous `DictionaryEntry` objects to type `WordAndCount`. This is because `DictionaryEntry` is a duplicate type of `WordAndCount`.
- Extend `src/app/components/ManualEntry.svelte` so that it can be used to edit existing dictionary sources
- Explicitly set `getLanguageSources` to type `Function`

UI:
![Screenshot_20210309_012643](https://user-images.githubusercontent.com/28885930/110444265-0b5de380-807a-11eb-8d7e-6c1e8cffa4c0.png)


Resolves #257
