### PR TITLE
Create SEO meta tag description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,16 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title> Predictive Text Studio </title>
-  <link href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400;0,700;1,400&family=Roboto+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="icon" href="favicon.svg">
-  <link rel="apple-touch-icon" href="apple-touch-icon.png">
-  <!-- TODO: insert SEO tags -->
-</head>
-<body>
-  <script src="app.js"></script>
-  <link rel='stylesheet' href='/global.css'>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Predictive Text Studio</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cabin:ital,wght@0,400;0,700;1,400&family=Roboto+Mono:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" href="favicon.svg" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+    <meta
+      name="description"
+      content="Create predictive text for YOUR language! Designed for Keyman, Predictive Text Studio generates a KMP file for you to add a custom predictive keyboard to your devices."
+    />
+  </head>
+  <body>
+    <script src="app.js"></script>
+    <link rel="stylesheet" href="/global.css" />
+  </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
     <meta
       name="description"
-      content="Create predictive text for YOUR language! Designed for Keyman, Predictive Text Studio generates a KMP file for you to add a custom predictive keyboard to your devices."
+      content="Create predictive text and autocorrect for YOUR language! Designed for Keyman, Predictive Text Studio makes a custom predictive keyboard for your devices using a spreadsheet of words in your language."
     />
   </head>
   <body>


### PR DESCRIPTION
Simple description for SEO tags. Will give users who search for PTS a better description from their search engine.
