### PR TITLE
feat(app): i18n tweaks

### DIFF
--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -7,12 +7,11 @@
   import Team from "./pages/Team.svelte";
   import Help from "./pages/Help.svelte";
 
-  import en from "./lang/en";
-  import ko from "./lang/ko";
+  import { locales } from "./lang";
 
   const [initialLocale] = window.navigator.languages;
 
-  dictionary.set({ en, ko });
+  dictionary.set(locales);
   init({
     fallbackLocale: "en",
     initialLocale,

--- a/src/app/App.svelte
+++ b/src/app/App.svelte
@@ -7,14 +7,12 @@
   import Team from "./pages/Team.svelte";
   import Help from "./pages/Help.svelte";
 
-  import { locales } from "./lang";
-
-  const [initialLocale] = window.navigator.languages;
+  import { locales, determinePreferredLocale, FALLBACK_LOCALE } from "./lang";
 
   dictionary.set(locales);
   init({
-    fallbackLocale: "en",
-    initialLocale,
+    fallbackLocale: FALLBACK_LOCALE, // hint: it's English
+    initialLocale: determinePreferredLocale(),
   });
 
   // Used for SSR. A falsy value is ignored by the Router.

--- a/src/app/lang/en.js
+++ b/src/app/lang/en.js
@@ -65,6 +65,7 @@ export default {
     },
     main: {
       title: "Welcome to Predictive Text Studio",
+      designed_for: "Designed for",
       add: "Add",
       prediction: "prediction",
       and: "and",

--- a/src/app/lang/en.ts
+++ b/src/app/lang/en.ts
@@ -1,6 +1,8 @@
+import type Localization from "./localization";
+
 export default {
   common: {
-    name: "Predictive Text Studio",
+    app_name: "Predictive Text Studio",
     back: "Back",
     help: "Help",
     excel: "Excel",
@@ -174,4 +176,4 @@ export default {
       team_members: "Team Members",
     },
   },
-};
+} as Localization;

--- a/src/app/lang/index.ts
+++ b/src/app/lang/index.ts
@@ -1,0 +1,4 @@
+import en from "./en";
+import ko from "./ko";
+
+export const locales = { en, ko };

--- a/src/app/lang/index.ts
+++ b/src/app/lang/index.ts
@@ -1,4 +1,28 @@
 import en from "./en";
 import ko from "./ko";
 
+/**
+ * Available locales (translations).
+ */
 export const locales = { en, ko };
+
+/**
+ * Which locale to use if none of the others work out.
+ * (spoilers: it's the generic English locale).
+ */
+export const FALLBACK_LOCALE = "en";
+
+/**
+ * Returns the first locale that we have translations for.
+ */
+export function determinePreferredLocale(): string {
+  const preferredLocales = navigator.languages || [navigator.language];
+
+  for (const desiredLocale of preferredLocales) {
+    if (locales.hasOwnProperty(desiredLocale)) {
+      return desiredLocale;
+    }
+  }
+
+  return FALLBACK_LOCALE;
+}

--- a/src/app/lang/ko.ts
+++ b/src/app/lang/ko.ts
@@ -1,6 +1,8 @@
+import type Localization from "./localization";
+
 export default {
   common: {
-    name: "Predictive Text Studio",
+    app_name: "Predictive Text Studio",
     back: "뒤로가기",
     help: "도움말",
     excel: "엑셀",
@@ -41,7 +43,8 @@ export default {
     keyboard_preview_alt: "iOS 영문 키보드",
     add_source: "소스 추가",
     add_row: "행 추가",
-    drag_and_drop: "Excel .xlsx 또는 TSV 파일을 여기로 드래그해서 업로드 하세요!",
+    drag_and_drop:
+      "Excel .xlsx 또는 TSV 파일을 여기로 드래그해서 업로드 하세요!",
     browse_file: "파일 찾아보기",
     advanced_options: "고급 옵션",
     only_works_with: "* .xlsx 파일 및 Google 스프레드 시트에서만 작동합니다",
@@ -174,4 +177,4 @@ export default {
       team_members: "개발팀",
     },
   },
-};
+} as Localization;

--- a/src/app/lang/localization.d.ts
+++ b/src/app/lang/localization.d.ts
@@ -1,0 +1,9 @@
+export default interface Localization {
+  [key: string]: Category;
+}
+
+interface Category {
+  [key: string]: Translation | Category;
+}
+
+type Translation = string;

--- a/src/app/pages/LandingPage.svelte
+++ b/src/app/pages/LandingPage.svelte
@@ -336,7 +336,7 @@
           Predictive Text Studio
         </h1>
         <p class="masthead__branding">
-          designed for
+          {$_('page.main.designed_for')}
           <img class="masthead__brand" alt="Keyman" src="/assets/keyman-logo.svg">
         </p>
         <p class="masthead__description">

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -168,7 +168,7 @@
       <header class="languages__container--header">
         <div>
           <h1>{$_('common.app_name')}</h1>
-          <p>designed for
+          <p>{$_('page.main.designed_for')}
             <img
             src="/assets/keyman-logo.svg"
             alt="Keyman" />

--- a/src/app/pages/Languages.svelte
+++ b/src/app/pages/Languages.svelte
@@ -167,7 +167,7 @@
       </a>
       <header class="languages__container--header">
         <div>
-          <h1>{$_('common.name')}</h1>
+          <h1>{$_('common.app_name')}</h1>
           <p>designed for
             <img
             src="/assets/keyman-logo.svg"


### PR DESCRIPTION
Improves localzation by:

 - implementing `determinePreferredLocale()`, which finds the first matching locale in common with our translations
 - moving translation files to TypeScript — it's already helped find an erroneous duplicate key!
 - accessing all locales from `./langs` instead of importing each locale manually.