### PR TITLE
refactor: extract LocalizableDate component

### DIFF
--- a/src/app/components/LocalizedDate.svelte
+++ b/src/app/components/LocalizedDate.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { date } from "svelte-i18n";
+
+  export let isodate: string;
+
+  /** Return the ISO date as a localtime Date object. */
+  function asLocalTimeDate() {
+    const match = /^(\d+)-(\d{1,2})-(\d{1,2})$/.exec(isodate);
+
+    if (!match) {
+      throw new Error(`Invalid ISO date: ${isodate} (expecting yyyy-mm-dd)`);
+    }
+
+    const [_, year, month, day] = match;
+    /*
+     * Although you COULD use the Date constructor to parse the ISO date, it's
+     * STONGLY DISCOURAGED, since different browser implememt different
+     * parsing heuristics! 😱
+     * It also assumes the date is in UTC, which is NOT what we want!
+     * See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#Timestamp_string
+     */
+    return new Date(+year, +month - 1, +day);
+  }
+</script>
+
+<time datetime={isodate}>{$date(asLocalTimeDate(), { format: 'long' })}</time>

--- a/src/app/lang/en.ts
+++ b/src/app/lang/en.ts
@@ -89,7 +89,6 @@ export default {
     privacy: {
       title: "Predictive Text Studio Privacy Policy",
       effective_as_of: "Effective as of",
-      date: "December 8, 2020",
       introduction: {
         title: "Introduction",
         head: {

--- a/src/app/lang/ko.ts
+++ b/src/app/lang/ko.ts
@@ -90,7 +90,6 @@ export default {
     privacy: {
       title: "Predictive Text Studio 개인 정보 정책",
       effective_as_of: "유효",
-      date: "2020년 12월 8일",
       introduction: {
         title: "소개",
         head: {

--- a/src/app/pages/Privacy.svelte
+++ b/src/app/pages/Privacy.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { _ } from "svelte-i18n";
+
+  import LocalizedDate from "../components/LocalizedDate.svelte";
 </script>
 
 <style>
@@ -30,7 +32,7 @@
     <h2>{$_('page.privacy.title')}</h2>
     <p>
       <strong>{$_('page.privacy.effective_as_of')}:</strong>
-      <time datetime="2020-12-08">{$_('page.privacy.date')}</time>
+      <LocalizedDate isodate="2020-12-08" />
     </p>
     <h3>{$_('page.privacy.introduction.title')}</h3>
     <p>{$_('page.privacy.introduction.head.0')}</p>


### PR DESCRIPTION
Removes the need to translate dates, as Svelte i18n can format dates FOR YOU (probably by using the [`Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)).

So now dates are automatically localized! ✨ 
 
<img width="551" alt="Korean localization" src="https://user-images.githubusercontent.com/2294397/113487078-2d793480-9473-11eb-8814-6658f4e93939.png">
<img width="549" alt="Spanish localization" src="https://user-images.githubusercontent.com/2294397/113487081-2e11cb00-9473-11eb-9d31-66fd860378b5.png">

