### PR TITLE
change: tweak copyright button

### DIFF
--- a/cypress/integration/copyright-button.spec.ts
+++ b/cypress/integration/copyright-button.spec.ts
@@ -13,13 +13,14 @@ describe("Adding © to the copyright field", function () {
 
     copyrightInput().its("value").should("be", copyright);
 
-    button().should("be.visible").click();
+    button().should("not.have.attr", "data-disabled");
+    button().click();
 
     copyrightInput()
       .its("value")
       .should("be", "© " + copyright);
 
-    button().should("not.be.visible");
+    button().should("have.attr", "data-disabled");
   });
 
   function copyrightInput() {

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -16,7 +16,8 @@
 
   /**
    * Whether the data-disabled=" prop should appear on the element.
-   * Note: this is only updated when PASSED enabled!
+   * Note: this is not automatically called when `enabled` is changed;
+   * you must explicitly pass `enabled` for this function to be called :/
    */
   function dataDisabledState(isEnabled: boolean): "disabled" | null {
     // exclude the prop entirely by setting the value to 'null'

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -9,6 +9,10 @@
   export let dataCy: string = ""; // optional
   export let enabled: boolean = true; // optional
   export let onClick: (ev: MouseEvent) => void;
+
+  function whenButtonDepressed(event) {
+    if (enabled) onClick(event);
+  }
 </script>
 
 <style>
@@ -23,9 +27,14 @@
     flex-direction: column;
     align-items: center;
   }
+
   .button--disabled {
-    background: var(--gray-disabled);
-    pointer-events: none;
+    cursor: not-allowed;
+  }
+
+  .button--disabled.button--outline {
+    color: var(--gray-disabled);
+    border-color: var(--gray-disabled);
   }
 
   @media (max-width: 768px) {
@@ -43,7 +52,7 @@
     class:button--outline={isOutlined}
     class:button--disabled={!enabled}
     {type}
-    on:click={onClick}
+    on:click={whenButtonDepressed}
     data-cy={dataCy}><slot /></button>
   {#if subtext}
     <p class="subtext mt-xs">{subtext}</p>

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -13,6 +13,16 @@
   function whenButtonDepressed(event) {
     if (enabled) onClick(event);
   }
+
+  /**
+   * Whether the data-disabled=" prop should appear on the element.
+   * Note: this is only updated when PASSED enabled!
+   */
+  function dataDisabledState(isEnabled) {
+    // exclude the prop entirely by setting the value to 'null'
+    // See: https://svelte.dev/docs#Attributes_and_props:~:text=All%20other%20attributes%20are%20included%20unless,%3Cinput
+    return !isEnabled ? "disabled" : null;
+  }
 </script>
 
 <style>
@@ -53,7 +63,8 @@
     class:button--disabled={!enabled}
     {type}
     on:click={whenButtonDepressed}
-    data-cy={dataCy}><slot /></button>
+    data-cy={dataCy}
+    data-disabled={dataDisabledState(enabled)}><slot /></button>
   {#if subtext}
     <p class="subtext mt-xs">{subtext}</p>
   {/if}

--- a/src/app/components/Button.svelte
+++ b/src/app/components/Button.svelte
@@ -10,7 +10,7 @@
   export let enabled: boolean = true; // optional
   export let onClick: (ev: MouseEvent) => void;
 
-  function whenButtonDepressed(event) {
+  function whenButtonDepressed(event: MouseEvent): void {
     if (enabled) onClick(event);
   }
 
@@ -18,7 +18,7 @@
    * Whether the data-disabled=" prop should appear on the element.
    * Note: this is only updated when PASSED enabled!
    */
-  function dataDisabledState(isEnabled) {
+  function dataDisabledState(isEnabled: boolean): "disabled" | null {
     // exclude the prop entirely by setting the value to 'null'
     // See: https://svelte.dev/docs#Attributes_and_props:~:text=All%20other%20attributes%20are%20included%20unless,%3Cinput
     return !isEnabled ? "disabled" : null;

--- a/src/app/components/LanguageInfo.svelte
+++ b/src/app/components/LanguageInfo.svelte
@@ -42,7 +42,7 @@
     ]);
   }
 
-  $: copyrightButtonEnabled = copyright !== "" && copyright.charAt(0) !== "©";
+  $: copyrightButtonEnabled = copyright.charAt(0) !== "©";
 
   function updateMetadata(key: any, value: any) {
     worker.setProjectData({ [key]: value });
@@ -145,15 +145,14 @@
       subtext="" />
   </div>
   <div class="copyright-field">
-    {#if copyrightButtonEnabled}
-      <Button
-        size="small"
-        color="blue"
-        isOutlined={true}
-        onClick={addCopyrightSymbol}>
-        {$_('page.lang.add_copyright_symbol')}
-      </Button>
-    {/if}
+    <Button
+      size="small"
+      enabled={copyrightButtonEnabled}
+      color="blue"
+      isOutlined={true}
+      onClick={addCopyrightSymbol}>
+      {$_('page.lang.add_copyright_symbol')}
+    </Button>
   </div>
   <div class="language__info-right">
     <p class="label">{$_('input.keyboard_preview')}</p>

--- a/src/app/components/LanguageInfo.svelte
+++ b/src/app/components/LanguageInfo.svelte
@@ -151,7 +151,7 @@
         color="blue"
         isOutlined={true}
         onClick={addCopyrightSymbol}>
-        {$_('common.add') + ' ©'}
+        {$_('page.lang.add_copyright_symbol')}
       </Button>
     {/if}
   </div>

--- a/src/app/lang/en.ts
+++ b/src/app/lang/en.ts
@@ -89,6 +89,7 @@ export default {
       information: "Information",
       sources: "Sources",
       download: "Download",
+      add_copyright_symbol: "Add ©",
     },
     privacy: {
       title: "Predictive Text Studio Privacy Policy",


### PR DESCRIPTION
Changes:

 - the entire button text is now localizable
 - the button is always visible; however, the button is disabled when invalid
 - you can add the copyright symbol when the string is empty