### PR TITLE
remove: cy.disableSmoothScroll()

### DIFF
--- a/cypress/integration/landingPage.spec.ts
+++ b/cypress/integration/landingPage.spec.ts
@@ -13,7 +13,6 @@ describe("Upload from the the landing page", () => {
     cy.visit("/");
     cy.task("clearDownloads");
     cy.allowUnlimitedDownloadsToFolder(downloadFolder);
-    cy.disableSmoothScroll();
   });
 
   // TODO: Removed due to bug #280. Should be re-introduced once bug #280 is resolved

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -40,18 +40,6 @@ Cypress.Commands.add("allowUnlimitedDownloadsToFolder", (folderName) => {
   }
 });
 
-Cypress.Commands.add("disableSmoothScroll", () => {
-  /**
-   * Disable css smooth scroll to avoid using "{ force:true }" in .type.
-   * See https://github.com/cypress-io/cypress/issues/3200
-   */
-  cy.document().then((document) => {
-    const node = document.createElement("style");
-    node.innerHTML = "html { scroll-behavior: inherit !important; }";
-    document.body.appendChild(node);
-  });
-});
-
 /**
  * Shortcut for cy.get("[data=NAME]")
  */
@@ -60,7 +48,7 @@ Cypress.Commands.add("data", (dataCy) => {
 });
 
 /**
- * Shortcut for cy.get("[data=NAME]")
+ * Promises the contents of a Zip file (e.g., a .kmp package).
  */
 Cypress.Commands.add("readZip", (filename) => {
   return cy.readFile(filename, "binary").then((contents) => {


### PR DESCRIPTION
Follow up to #296. Removes missed `cy.disableSmoothScroll()` and removes the command entirely! 
