### PR TITLE
update: reduce wait time still fix flakiness

### DIFF
--- a/cypress/integration/copyright-button.spec.ts
+++ b/cypress/integration/copyright-button.spec.ts
@@ -7,7 +7,7 @@ describe("Adding © to the copyright field", function () {
     cy.data("input-copyright").scrollIntoView();
 
     // HACK: it has to wait for the existing project to load
-    cy.wait(2000);
+    cy.wait(1500);
 
     copyrightInput().clear().type(copyright).blur();
 


### PR DESCRIPTION
Hello! 
Our team is investigating the impact of waiting time on flaky testing in asynchronous issues. We use your project and test code as one of our research data cases. Our experiments and test data have demonstrated that if the waiting time in the current test file is adjusted from 2000ms to 1500ms, it can still guarantee the success of all 100 rerun tests, and can also mitigate the running time of test files to a certain extent.

The new waiting time can alleviate flakiness while saving test execution time compared to the original time values.

We appreciate your consideration and look forward to hearing your thoughts and feedback.